### PR TITLE
Define __PAYPAL_BRAINTREE_QUERY_OPTIONS__ and __PAYPAL_BRAINTREE_SERVER_CONFIG__ as null for static build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,8 +12,10 @@ const FILE_NAME = 'paypal-braintree-sdk-client';
 const MODULE_NAME = 'btppClientConfig';
 
 const DEFAULT_VARS = {
-    __TEST__: false,
-    __MIN__:  false
+    __TEST__:                           false,
+    __MIN__:                            false,
+    __PAYPAL_BRAINTREE_SERVER_CONFIG__: null,
+    __PAYPAL_BRAINTREE_QUERY_OPTIONS__: null
 };
 
 type WebpackConfigOptions = {


### PR DESCRIPTION
For the server-side integration, we can use `webpack.DefinePlugin` to inline anything we need into the generated bundle.

There are two immediate cases where we want to do this:

- Query options (passed to paypal.com/foo.js?merchantID=xxx&modules=xyz,abc)
- Server config (generated based on merchant id, locale, whatever other factors)

This doesn't work for the CDN model though; hence, for the webpack build to /dist, nulling these out for now.

Note: these will both be passed to `attach()` to be used by individual components. There's an example here: https://github.com/paypal/paypal-braintree-example-component/blob/master/src/index.js#L6 -- but obviously they'll be null if we go with the CDN approach in the short term.