### PR TITLE
Fix misspelling in error message

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -21,7 +21,7 @@ export function getSDKScript() : HTMLScriptElement {
         const script = getScript({ host, path });
 
         if (!script) {
-            throw new Error(`PayPal Payments SDK script not present on page! Excected to find <script src="https://${ host }${ path }">`);
+            throw new Error(`PayPal Payments SDK script not present on page! Expected to find <script src="https://${ host }${ path }">`);
         }
 
         return script;


### PR DESCRIPTION
Change "Excected" -> "Expected" in the following error message

<img width="877" alt="Screen Shot 2020-08-20 at 3 07 45 PM" src="https://user-images.githubusercontent.com/40329316/91185945-06c07780-e6b4-11ea-8992-61abda032990.png">

JIRA: https://engineering.paypalcorp.com/jira/browse/DTCHKINT-219
