### PR TITLE
Update logging to support uid-auto attribute

### DIFF
--- a/src/tracking.js
+++ b/src/tracking.js
@@ -24,7 +24,7 @@ export function setupLogger() {
     const logger = getLogger();
 
     sdkInitTime = Date.now();
-    
+
     logger.addPayloadBuilder(() => {
         return {
             referer: window.location.host,
@@ -76,7 +76,7 @@ export function setupLogger() {
         const sdkScript = getSDKScript();
         const loadTime = getResourceLoadTime(sdkScript.src);
         let cache;
-    
+
         if (loadTime === 0) {
             cache = 'sdk_client_cache_hit';
         } else if (typeof loadTime === 'number') {
@@ -84,11 +84,13 @@ export function setupLogger() {
         } else {
             cache = 'sdk_client_cache_unknown';
         }
-    
+
+        const hasAttributeUID = sdkScript.hasAttribute(ATTRIBUTES.UID) || sdkScript.hasAttribute(`${ ATTRIBUTES.UID }-auto`);
+
         logger
             .info(`setup_${ getEnv() }`)
             .info(`setup_${ getEnv() }_${ getVersion().replace(/\./g, '_') }`)
-            .info(`sdk_${ isPayPalDomain() ? 'paypal' : 'non_paypal' }_domain_script_uid_${ sdkScript.hasAttribute(ATTRIBUTES.UID) ? 'present' : 'missing' }`)
+            .info(`sdk_${ isPayPalDomain() ? 'paypal' : 'non_paypal' }_domain_script_uid_${ hasAttributeUID ? 'present' : 'missing' }`)
             .info(cache)
             .track({
                 [FPTI_KEY.TRANSITION]:    'process_js_sdk_init_client',


### PR DESCRIPTION
I noticed that the initial script uses `data-uid-auto` as the data attribute for storing the uid which is causing the logger to fire a `sdk_non_paypal_domain_script_uid_missing` event. I'm assuming it should be firing a `sdk_non_paypal_domain_script_uid_present` event instead.

<img width="1069" alt="Screen Shot 2020-11-16 at 9 41 39 PM" src="https://user-images.githubusercontent.com/534034/99343968-9cebe000-2854-11eb-8498-31fbea40708b.png">

This PR updates the logging logic to work for both `data-uid` and `data-uid-auto`.

This commit introduced the data-uid-auto change: https://github.com/krakenjs/belter/commit/d4fee71912241da03ba039a032b7d22e0ba710e7. 