### PR TITLE
Update belter to support data-uid

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@paypal/sdk-constants": "^1.0.61",
     "beaver-logger": "^4.0.0",
-    "belter": "^1.0.16",
+    "belter": "^1.0.136",
     "bowser": "^2.0.0",
     "jsx-pragmatic": "^2",
     "zalgo-promise": "^1.0.22"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@paypal/sdk-constants": "^1.0.61",
     "beaver-logger": "^4.0.0",
-    "belter": "^1.0.136",
+    "belter": "^1.0.146",
     "bowser": "^2.0.0",
     "jsx-pragmatic": "^2",
     "zalgo-promise": "^1.0.22"


### PR DESCRIPTION
Support for `data-uid` was added to belter@1.0.136 so we need sdk-client to be using at least that. 

https://github.com/krakenjs/belter/compare/v1.0.135...v1.0.136

I ran into this problem when updating a private server-side app to use the latest sdk-client.