### PR TITLE
Added sandbox and test client-id aliases

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -13,8 +13,12 @@ export const SUPPORTED_BROWSERS = {
     vivaldi:        '1.91'
 };
 
+const SANDBOX_ALIAS = 'AZDxjDScFpQtjWTOUtWKbyN_bDt4OgqaF4eYXlewfBP4-8aqX3PiV8e1GWU6liB2CUXlkA59kJXE7M6R';
+
 export const CLIENT_ID_ALIAS = {
-    sb: 'AZDxjDScFpQtjWTOUtWKbyN_bDt4OgqaF4eYXlewfBP4-8aqX3PiV8e1GWU6liB2CUXlkA59kJXE7M6R'
+    sandbox:    SANDBOX_ALIAS,
+    sb:         SANDBOX_ALIAS,
+    test:       SANDBOX_ALIAS
 };
 
 export const URI = {


### PR DESCRIPTION
This is pretty minor, but the Dev Docs team thought it'd be a good idea. I don't see why not. "sb" might not be obvious to people right away. 

Added sandbox and test client-id aliases, then we'll update the https://developer.paypal.com/demo/checkout/#/pattern/client tool and other places it appears.