### PR TITLE
Fix local check

### DIFF
--- a/server/constants.js
+++ b/server/constants.js
@@ -4,7 +4,7 @@ export const HOST = {
     LOCALHOST:      'localhost.paypal.com',
     PAYPAL:         '.paypal.com',
     PAYPALOBJECTS:  'www.paypalobjects.com',
-    LOCALTUNNEL:    'paypal.loca.lt',
+    LOCALTUNNEL:    'loca.lt',
     LOCALHOST_8000: 'localhost:8000',
     LOCALHOST_8443: 'localhost:8443'
 };

--- a/server/meta.jsx
+++ b/server/meta.jsx
@@ -78,7 +78,7 @@ function isLocalUrl(host : string) : boolean {
     const localUrls = [ HOST.LOCALHOST_8000, HOST.LOCALHOST_8443, HOST.LOCALTUNNEL ];
     
     // eslint-disable-next-line no-process-env
-    return process.env.NODE_ENV !== ENV.PRODUCTION && localUrls.some(url => host.includes(url));
+    return process.env.NODE_ENV === 'development' && localUrls.some(url => host.includes(url));
 }
 
 function validateSDKUrl(sdkUrl : string) {

--- a/server/meta.jsx
+++ b/server/meta.jsx
@@ -78,7 +78,7 @@ function isLocalUrl(host : string) : boolean {
     const localUrls = [ HOST.LOCALHOST_8000, HOST.LOCALHOST_8443, HOST.LOCALTUNNEL ];
     
     // eslint-disable-next-line no-process-env
-    return process.env.NODE_ENV === ENV.LOCAL && localUrls.some(url => host === url);
+    return process.env.NODE_ENV !== ENV.PRODUCTION && localUrls.some(url => host.includes(url));
 }
 
 function validateSDKUrl(sdkUrl : string) {

--- a/test/server/meta.test.js
+++ b/test/server/meta.test.js
@@ -62,7 +62,7 @@ test('should construct a valid script url with checkout.js on localhost', () => 
 
 test('should construct a script url with checkout.js on localhost without a paypal.com domain', () => {
     // eslint-disable-next-line no-process-env
-    process.env.NODE_ENV = 'local';
+    process.env.NODE_ENV = 'development';
 
     const sdkUrl = 'http://localhost:8000/api/checkout.js';
 

--- a/test/server/meta.test.js
+++ b/test/server/meta.test.js
@@ -83,7 +83,7 @@ test('should construct a script url with checkout.js on localhost without a payp
 
 test('should not construct a script url with checkout.js for non-supported local urls', () => {
     // eslint-disable-next-line no-process-env
-    process.env.NODE_ENV = 'local';
+    process.env.NODE_ENV = 'development';
     
     const sdkUrl = 'http://not.a.supported.url:8000/api/checkout.js';
 


### PR DESCRIPTION
Current env is not set and smartcomponentnodeweb breaks if run with `NODE_ENV` set to local.  Also, local tunnel is not letting us keep our PayPal subdomain and so changing how we inspect the urls.