### PR TITLE
Update getCSPNonce to always return a string

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -238,8 +238,8 @@ export function getLocale() : LocaleType {
     };
 }
 
-export function getCSPNonce() : ?string {
-    return getSDKAttribute(SDK_SETTINGS.CSP_NONCE);
+export function getCSPNonce() : string {
+    return getSDKAttribute(SDK_SETTINGS.CSP_NONCE) || '';
 }
 
 export function getEnableThreeDomainSecure() : boolean {


### PR DESCRIPTION
This PR updates `getCSPNonce` to return an empty string by default. This will make it easier enforce the csp nonce values in paypal-checkout-components by making them required strings.