### PR TITLE
[DTCHKINT-244] Check for single country match from locale lang

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -224,20 +224,25 @@ export function getLocale() : LocaleType {
             return { country, lang };
         } else {
             // We will infer country from language if there is only one possible country match
-            const possibleCountries = Object.keys(COUNTRY_LANGS).filter((possibleCountry) => {
+            let possibleLocales = [];
+            for(let possibleCountry of Object.keys(COUNTRY_LANGS)) {
                 const languages = COUNTRY_LANGS[possibleCountry];
 
+                console.log('possible country', possibleCountry);
+                // console.log('languages', languages);
+
                 if (languages.length && languages.some(language => language === lang)) {
-                    return true;
+                    const language = languages.find(x => x === lang);
+                    possibleLocales.push({country: possibleCountry, lang: language});
                 }
 
-                return false;
-            });
+                if (possibleLocales.length > 1) {
+                    break;
+                }
+            }
 
-            const languageKey = Object.keys(LANG).filter(possibleLanguage => LANG[possibleLanguage] === lang)[0];
-            const language = LANG[languageKey];
-            if (possibleCountries.length === 1 && COUNTRY[possibleCountries[0]] && language) {
-                return { country: possibleCountries[0], lang: language };
+            if (possibleLocales.length === 1) {
+                return possibleLocales[0];
             }
         }
     }

--- a/src/script.js
+++ b/src/script.js
@@ -223,23 +223,19 @@ export function getLocale() : LocaleType {
             // $FlowFixMe
             return { country, lang };
         } else {
-            // We will infer country from language if there is only one possible country match
-            const possibleLocales = [];
-            for (const possibleCountry of Object.keys(COUNTRY_LANGS)) {
-                const languages = COUNTRY_LANGS[possibleCountry];
-                const language = languages.find(x => x === lang);
-
-                if (language) {
-                    possibleLocales.push({ country: possibleCountry, lang: language });
-                }
-
-                if (possibleLocales.length > 1) {
-                    break;
-                }
+            // We infer country from language if there is only one possible country match
+            const possibleCountries = Object.keys(COUNTRY_LANGS).filter(x => COUNTRY_LANGS[x].some(y => y === lang));
+            
+            if (possibleCountries.length !== 1) {
+                break;
             }
 
-            if (possibleLocales.length === 1 && possibleLocales[0]) {
-                return possibleLocales[0];
+            const possibleCountry = possibleCountries[0];
+            const languages = COUNTRY_LANGS[possibleCountry];
+            const language = languages.find(x => x === lang);
+
+            if (language) {
+                return { country: possibleCountry, lang: language };
             }
         }
     }

--- a/src/script.js
+++ b/src/script.js
@@ -224,16 +224,13 @@ export function getLocale() : LocaleType {
             return { country, lang };
         } else {
             // We will infer country from language if there is only one possible country match
-            let possibleLocales = [];
-            for(let possibleCountry of Object.keys(COUNTRY_LANGS)) {
+            const possibleLocales = [];
+            for (const possibleCountry of Object.keys(COUNTRY_LANGS)) {
                 const languages = COUNTRY_LANGS[possibleCountry];
+                const language = languages.find(x => x === lang);
 
-                console.log('possible country', possibleCountry);
-                // console.log('languages', languages);
-
-                if (languages.length && languages.some(language => language === lang)) {
-                    const language = languages.find(x => x === lang);
-                    possibleLocales.push({country: possibleCountry, lang: language});
+                if (language) {
+                    possibleLocales.push({ country: possibleCountry, lang: language });
                 }
 
                 if (possibleLocales.length > 1) {
@@ -241,7 +238,7 @@ export function getLocale() : LocaleType {
                 }
             }
 
-            if (possibleLocales.length === 1) {
+            if (possibleLocales.length === 1 && possibleLocales[0]) {
                 return possibleLocales[0];
             }
         }

--- a/src/script.js
+++ b/src/script.js
@@ -224,27 +224,21 @@ export function getLocale() : LocaleType {
             return { country, lang };
         } else {
             // We will infer country from language if there is only one possible country match
-            // $FlowFixMe
-            const possibleCountries = [];
-            // $FlowFixMe
-            for (const possibleCountry in COUNTRY_LANGS) {
-                if (COUNTRY_LANGS.hasOwnProperty(possibleCountry)) {
-                    if (possibleCountries.length > 1) {
-                        break;
-                    }
+            const possibleCountries = Object.keys(COUNTRY_LANGS).filter((possibleCountry) => {
+                const languages = COUNTRY_LANGS[possibleCountry];
 
-                    // $FlowFixMe
-                    const languages = COUNTRY_LANGS[possibleCountry];
-
-                    if (languages.length && languages.some(language => language === lang)) {
-                        possibleCountries.push(possibleCountry);
-                    }
+                if (languages.length && languages.some(language => language === lang)) {
+                    return true;
                 }
-            }
 
-            if (possibleCountries.length === 1) {
-                // $FlowFixMe
-                return { country: possibleCountries[0], lang };
+                return false;
+            });
+
+            const inferredCountry = COUNTRY[possibleCountries[0]];
+            const languageKey = Object.keys(LANG).filter(possibleLanguage => LANG[possibleLanguage] === lang)[0];
+            const language = LANG[languageKey];
+            if (possibleCountries.length === 1 && inferredCountry && language) {
+                return { country: inferredCountry, lang: language };
             }
         }
     }

--- a/src/script.js
+++ b/src/script.js
@@ -222,6 +222,30 @@ export function getLocale() : LocaleType {
         if (COUNTRY_LANGS.hasOwnProperty(country) && COUNTRY_LANGS[country].indexOf(lang) !== -1) {
             // $FlowFixMe
             return { country, lang };
+        } else {
+            // We will infer country from language if there is only one possible country match
+            // $FlowFixMe
+            const possibleCountries = [];
+            // $FlowFixMe
+            for (const possibleCountry in COUNTRY_LANGS) {
+                if (COUNTRY_LANGS.hasOwnProperty(possibleCountry)) {
+                    if (possibleCountries.length > 1) {
+                        break;
+                    }
+
+                    // $FlowFixMe
+                    const languages = COUNTRY_LANGS[possibleCountry];
+
+                    if (languages.length && languages.some(language => language === lang)) {
+                        possibleCountries.push(possibleCountry);
+                    }
+                }
+            }
+
+            if (possibleCountries.length === 1) {
+                // $FlowFixMe
+                return { country: possibleCountries[0], lang };
+            }
         }
     }
 

--- a/src/script.js
+++ b/src/script.js
@@ -217,25 +217,19 @@ export function getLocale() : LocaleType {
         return { lang, country };
     }
 
-    for (const { country, lang } of getBrowserLocales()) {
-        // $FlowFixMe
-        if (COUNTRY_LANGS.hasOwnProperty(country) && COUNTRY_LANGS[country].indexOf(lang) !== -1) {
-            // $FlowFixMe
+    for (let { country, lang } of getBrowserLocales()) {
+        country = country && COUNTRY[country];
+        lang = lang && LANG[lang.toUpperCase()];
+
+        if (country && lang && COUNTRY_LANGS[country] && COUNTRY_LANGS[country].indexOf(lang) !== -1) {
             return { country, lang };
-        } else {
+        } else if (lang) {
             // We infer country from language if there is only one possible country match
-            const possibleCountries = Object.keys(COUNTRY_LANGS).filter(x => COUNTRY_LANGS[x].some(y => y === lang));
+            const possibleCountries = Object.keys(COUNTRY_LANGS).filter(c => COUNTRY_LANGS[c].some(l => l === lang));
             
-            if (possibleCountries.length !== 1) {
-                break;
-            }
-
-            const possibleCountry = possibleCountries[0];
-            const languages = COUNTRY_LANGS[possibleCountry];
-            const language = languages.find(x => x === lang);
-
-            if (language) {
-                return { country: possibleCountry, lang: language };
+            if (possibleCountries.length === 1) {
+                const possibleCountry = possibleCountries[0];
+                return { country: possibleCountry, lang };
             }
         }
     }

--- a/src/script.js
+++ b/src/script.js
@@ -234,11 +234,10 @@ export function getLocale() : LocaleType {
                 return false;
             });
 
-            const inferredCountry = COUNTRY[possibleCountries[0]];
             const languageKey = Object.keys(LANG).filter(possibleLanguage => LANG[possibleLanguage] === lang)[0];
             const language = LANG[languageKey];
-            if (possibleCountries.length === 1 && inferredCountry && language) {
-                return { country: inferredCountry, lang: language };
+            if (possibleCountries.length === 1 && COUNTRY[possibleCountries[0]] && language) {
+                return { country: possibleCountries[0], lang: language };
             }
         }
     }

--- a/test/client/script.js
+++ b/test/client/script.js
@@ -360,7 +360,7 @@ describe(`script cases`, () => {
         const localeObject = getLocale();
         const receivedLocal = `${ localeObject.lang }_${ localeObject.country }`;
         if (expectedLocale !== receivedLocal) {
-            throw new Error(`Expected client id to be ${ expectedLocale }, got ${ receivedLocal } from ${ url }`);
+            throw new Error(`Expected locale to be ${ expectedLocale }, got ${ receivedLocal } from ${ url }`);
         }
     });
 
@@ -372,7 +372,7 @@ describe(`script cases`, () => {
         const receivedLocale = `${ localeObject.lang }_${ localeObject.country }`;
 
         if (expectedLocale !== receivedLocale) {
-            throw new Error(`Expected client id to be ${ expectedLocale }, got ${ receivedLocale }`);
+            throw new Error(`Expected locale to be ${ expectedLocale }, got ${ receivedLocale }`);
         }
     });
 
@@ -384,7 +384,7 @@ describe(`script cases`, () => {
         const receivedLocale = `${ localeObject.lang }_${ localeObject.country }`;
 
         if (expectedLocale !== receivedLocale) {
-            throw new Error(`Expected client id to be ${ expectedLocale }, got ${ receivedLocale }`);
+            throw new Error(`Expected locale to be ${ expectedLocale }, got ${ receivedLocale }`);
         }
     });
 
@@ -396,7 +396,7 @@ describe(`script cases`, () => {
         const receivedLocale = `${ localeObject.lang }_${ localeObject.country }`;
 
         if (expectedLocale !== receivedLocale) {
-            throw new Error(`Expected client id to be ${ expectedLocale }, got ${ receivedLocale }`);
+            throw new Error(`Expected locale to be ${ expectedLocale }, got ${ receivedLocale }`);
         }
     });
 
@@ -407,7 +407,7 @@ describe(`script cases`, () => {
         const receivedLocale = `${ localeObject.lang }_${ localeObject.country }`;
 
         if (expectedLocale !== receivedLocale) {
-            throw new Error(`Expected client id to be ${ expectedLocale }, got ${ receivedLocale }`);
+            throw new Error(`Expected locale to be ${ expectedLocale }, got ${ receivedLocale }`);
         }
     });
 });

--- a/test/client/script.js
+++ b/test/client/script.js
@@ -1,4 +1,5 @@
 /* @flow */
+/* eslint-disable compat/compat */
 
 import { base64encode } from 'belter/src';
 
@@ -7,10 +8,8 @@ import { getClientID, getIntent, getCurrency, getVault, getCommit, getClientToke
 
 describe(`script cases`, () => {
     beforeEach(() => {
-        /* eslint-disable compat/compat */
         Object.defineProperty(window.navigator, 'languages', { value: [], writable: true });
         Object.defineProperty(window.navigator, 'language', { value: '', writable: true });
-        /* eslint-enable compat/compat */
 
     });
 
@@ -367,7 +366,7 @@ describe(`script cases`, () => {
 
     it('should successfully get locale from browser settings', () => {
         const expectedLocale = 'fr_FR';
-        window.navigator.languages = [ expectedLocale ]; // eslint-disable-line compat/compat
+        window.navigator.languages = [ expectedLocale ];
 
         const localeObject = getLocale();
         const receivedLocale = `${ localeObject.lang }_${ localeObject.country }`;
@@ -379,7 +378,7 @@ describe(`script cases`, () => {
 
     it('should infer locale country from language', () => {
         const expectedLocale = 'ja_JP';
-        window.navigator.languages = [ 'ja' ]; // eslint-disable-line compat/compat
+        window.navigator.languages = [ 'ja' ];
 
         const localeObject = getLocale();
         const receivedLocale = `${ localeObject.lang }_${ localeObject.country }`;
@@ -400,3 +399,4 @@ describe(`script cases`, () => {
         }
     });
 });
+/* eslint-enable compat/compat */

--- a/test/client/script.js
+++ b/test/client/script.js
@@ -388,6 +388,18 @@ describe(`script cases`, () => {
         }
     });
 
+    it('should return default if unable to infer locale country', () => {
+        const expectedLocale = 'en_US';
+        window.navigator.languages = [ 'es' ];
+
+        const localeObject = getLocale();
+        const receivedLocale = `${ localeObject.lang }_${ localeObject.country }`;
+
+        if (expectedLocale !== receivedLocale) {
+            throw new Error(`Expected client id to be ${ expectedLocale }, got ${ receivedLocale }`);
+        }
+    });
+
     it('should return default locale if none detected', () => {
         const expectedLocale = 'en_US';
 

--- a/test/client/script.js
+++ b/test/client/script.js
@@ -3,7 +3,7 @@
 import { base64encode } from 'belter/src';
 
 import { getClientID, getIntent, getCurrency, getVault, getCommit, getClientToken, getPartnerAttributionID,
-    getMerchantID, getClientAccessToken, getSDKIntegrationSource, insertMockSDKScript, getPageType } from '../../src';
+    getMerchantID, getClientAccessToken, getSDKIntegrationSource, insertMockSDKScript, getPageType, getLocale } from '../../src';
 
 describe(`script cases`, () => {
     it('should successfully get a client id', () => {
@@ -338,6 +338,79 @@ describe(`script cases`, () => {
 
         if (getPageType() !== '') {
             throw new Error(`Expected page type to be empty, got ${ getPageType() || 'undefined' } from ${ url }`);
+        }
+    });
+
+    it('should successfully get locale from script', () => {
+        const expectedLocale = 'en_US';
+
+        const url = insertMockSDKScript({
+            query: {
+                'locale': expectedLocale
+            }
+        });
+
+        const localeObject = getLocale();
+        const receivedLocal = `${ localeObject.lang }_${ localeObject.country }`;
+        if (expectedLocale !== receivedLocal) {
+            throw new Error(`Expected client id to be ${ expectedLocale }, got ${ receivedLocal } from ${ url }`);
+        }
+    });
+
+    it('should successfully get locale from browser settings', () => {
+        const expectedLocale = 'en_US';
+
+        // $FlowFixMe
+        Object.defineProperty(navigator, 'languages', {
+            get:          () => [ expectedLocale ],
+            configurable: true
+        });
+
+        const localeObject = getLocale();
+        const receivedLocale = `${ localeObject.lang }_${ localeObject.country }`;
+
+        if (expectedLocale !== receivedLocale) {
+            throw new Error(`Expected client id to be ${ expectedLocale }, got ${ receivedLocale }`);
+        }
+    });
+
+    it('should infer locale country from language', () => {
+        const expectedLocale = 'ja_JP';
+
+        // $FlowFixMe
+        Object.defineProperty(navigator, 'languages', {
+            get:          () => [ 'ja' ],
+            configurable: true
+        });
+
+        const localeObject = getLocale();
+        const receivedLocale = `${ localeObject.lang }_${ localeObject.country }`;
+
+        if (expectedLocale !== receivedLocale) {
+            throw new Error(`Expected client id to be ${ expectedLocale }, got ${ receivedLocale }`);
+        }
+    });
+
+    it('should return default locale if none detected', () => {
+        const expectedLocale = 'en_US';
+
+        // $FlowFixMe
+        Object.defineProperty(navigator, 'languages', {
+            get:          () => [],
+            configurable: true
+        });
+
+        // $FlowFixMe
+        Object.defineProperty(navigator, 'language', {
+            get:          () => '',
+            configurable: true
+        });
+
+        const localeObject = getLocale();
+        const receivedLocale = `${ localeObject.lang }_${ localeObject.country }`;
+
+        if (expectedLocale !== receivedLocale) {
+            throw new Error(`Expected client id to be ${ expectedLocale }, got ${ receivedLocale }`);
         }
     });
 });

--- a/test/client/script.js
+++ b/test/client/script.js
@@ -359,9 +359,9 @@ describe(`script cases`, () => {
 
     it('should successfully get locale from browser settings', () => {
         const expectedLocale = 'en_US';
+        const defineProp = Object.defineProperty;
 
-        // $FlowFixMe
-        Object.defineProperty(navigator, 'languages', {
+        defineProp(navigator, 'languages', {
             get:          () => [ expectedLocale ],
             configurable: true
         });
@@ -376,9 +376,9 @@ describe(`script cases`, () => {
 
     it('should infer locale country from language', () => {
         const expectedLocale = 'ja_JP';
+        const defineProp = Object.defineProperty;
 
-        // $FlowFixMe
-        Object.defineProperty(navigator, 'languages', {
+        defineProp(navigator, 'languages', {
             get:          () => [ 'ja' ],
             configurable: true
         });
@@ -393,15 +393,14 @@ describe(`script cases`, () => {
 
     it('should return default locale if none detected', () => {
         const expectedLocale = 'en_US';
+        const defineProp = Object.defineProperty;
 
-        // $FlowFixMe
-        Object.defineProperty(navigator, 'languages', {
+        defineProp(navigator, 'languages', {
             get:          () => [],
             configurable: true
         });
 
-        // $FlowFixMe
-        Object.defineProperty(navigator, 'language', {
+        defineProp(navigator, 'language', {
             get:          () => '',
             configurable: true
         });

--- a/test/client/script.js
+++ b/test/client/script.js
@@ -7,8 +7,10 @@ import { getClientID, getIntent, getCurrency, getVault, getCommit, getClientToke
 
 describe(`script cases`, () => {
     beforeEach(() => {
+        /* eslint-disable compat/compat */
         Object.defineProperty(window.navigator, 'languages', { value: [], writable: true });
         Object.defineProperty(window.navigator, 'language', { value: '', writable: true });
+        /* eslint-enable compat/compat */
 
     });
 
@@ -365,7 +367,7 @@ describe(`script cases`, () => {
 
     it('should successfully get locale from browser settings', () => {
         const expectedLocale = 'fr_FR';
-        window.navigator.languages = [ expectedLocale ];
+        window.navigator.languages = [ expectedLocale ]; // eslint-disable-line compat/compat
 
         const localeObject = getLocale();
         const receivedLocale = `${ localeObject.lang }_${ localeObject.country }`;
@@ -377,7 +379,7 @@ describe(`script cases`, () => {
 
     it('should infer locale country from language', () => {
         const expectedLocale = 'ja_JP';
-        window.navigator.languages = [ 'ja' ];
+        window.navigator.languages = [ 'ja' ]; // eslint-disable-line compat/compat
 
         const localeObject = getLocale();
         const receivedLocale = `${ localeObject.lang }_${ localeObject.country }`;

--- a/test/client/script.js
+++ b/test/client/script.js
@@ -6,6 +6,12 @@ import { getClientID, getIntent, getCurrency, getVault, getCommit, getClientToke
     getMerchantID, getClientAccessToken, getSDKIntegrationSource, insertMockSDKScript, getPageType, getLocale } from '../../src';
 
 describe(`script cases`, () => {
+    beforeEach(() => {
+        Object.defineProperty(window.navigator, 'languages', { value: [], writable: true });
+        Object.defineProperty(window.navigator, 'language', { value: '', writable: true });
+
+    });
+
     it('should successfully get a client id', () => {
         const clientID = 'foobar123';
 
@@ -342,7 +348,7 @@ describe(`script cases`, () => {
     });
 
     it('should successfully get locale from script', () => {
-        const expectedLocale = 'en_US';
+        const expectedLocale = 'es_ES';
 
         const url = insertMockSDKScript({
             query: {
@@ -358,13 +364,8 @@ describe(`script cases`, () => {
     });
 
     it('should successfully get locale from browser settings', () => {
-        const expectedLocale = 'en_US';
-        const defineProp = Object.defineProperty;
-
-        defineProp(navigator, 'languages', {
-            get:          () => [ expectedLocale ],
-            configurable: true
-        });
+        const expectedLocale = 'fr_FR';
+        window.navigator.languages = [ expectedLocale ];
 
         const localeObject = getLocale();
         const receivedLocale = `${ localeObject.lang }_${ localeObject.country }`;
@@ -376,12 +377,7 @@ describe(`script cases`, () => {
 
     it('should infer locale country from language', () => {
         const expectedLocale = 'ja_JP';
-        const defineProp = Object.defineProperty;
-
-        defineProp(navigator, 'languages', {
-            get:          () => [ 'ja' ],
-            configurable: true
-        });
+        window.navigator.languages = [ 'ja' ];
 
         const localeObject = getLocale();
         const receivedLocale = `${ localeObject.lang }_${ localeObject.country }`;
@@ -393,17 +389,6 @@ describe(`script cases`, () => {
 
     it('should return default locale if none detected', () => {
         const expectedLocale = 'en_US';
-        const defineProp = Object.defineProperty;
-
-        defineProp(navigator, 'languages', {
-            get:          () => [],
-            configurable: true
-        });
-
-        defineProp(navigator, 'language', {
-            get:          () => '',
-            configurable: true
-        });
 
         const localeObject = getLocale();
         const receivedLocale = `${ localeObject.lang }_${ localeObject.country }`;

--- a/test/client/script.js
+++ b/test/client/script.js
@@ -1,5 +1,4 @@
 /* @flow */
-/* eslint-disable compat/compat */
 
 import { base64encode } from 'belter/src';
 
@@ -8,8 +7,8 @@ import { getClientID, getIntent, getCurrency, getVault, getCommit, getClientToke
 
 describe(`script cases`, () => {
     beforeEach(() => {
-        Object.defineProperty(window.navigator, 'languages', { value: [], writable: true });
-        Object.defineProperty(window.navigator, 'language', { value: '', writable: true });
+        Object.defineProperty(window.navigator, 'languages', { value: [], writable: true }); // eslint-disable-line compat/compat
+        Object.defineProperty(window.navigator, 'language', { value: '', writable: true }); // eslint-disable-line compat/compat
 
     });
 
@@ -366,7 +365,7 @@ describe(`script cases`, () => {
 
     it('should successfully get locale from browser settings', () => {
         const expectedLocale = 'fr_FR';
-        window.navigator.languages = [ expectedLocale ];
+        window.navigator.languages = [ expectedLocale ]; // eslint-disable-line compat/compat
 
         const localeObject = getLocale();
         const receivedLocale = `${ localeObject.lang }_${ localeObject.country }`;
@@ -378,7 +377,7 @@ describe(`script cases`, () => {
 
     it('should infer locale country from language', () => {
         const expectedLocale = 'ja_JP';
-        window.navigator.languages = [ 'ja' ];
+        window.navigator.languages = [ 'ja' ]; // eslint-disable-line compat/compat
 
         const localeObject = getLocale();
         const receivedLocale = `${ localeObject.lang }_${ localeObject.country }`;
@@ -390,7 +389,7 @@ describe(`script cases`, () => {
 
     it('should return default if unable to infer locale country', () => {
         const expectedLocale = 'en_US';
-        window.navigator.languages = [ 'es' ];
+        window.navigator.languages = [ 'es' ]; // eslint-disable-line compat/compat
 
         const localeObject = getLocale();
         const receivedLocale = `${ localeObject.lang }_${ localeObject.country }`;
@@ -411,4 +410,3 @@ describe(`script cases`, () => {
         }
     });
 });
-/* eslint-enable compat/compat */


### PR DESCRIPTION
Sometimes when pulling locale from browser settings, we only receive a language without a country code. In cases where there is only one possible country match, we should be able to safely infer the correct country from the language provided.

- Check that there is only one possible country match for the provided language and use it for locale
- Add tests for `getLocale` to cover new code change and some existing cases