### PR TITLE
Add support for using v4 from qa cdn

### DIFF
--- a/server/constants.js
+++ b/server/constants.js
@@ -1,12 +1,13 @@
 /* @flow */
 
 export const HOST = {
-    LOCALHOST:      'localhost.paypal.com',
-    PAYPAL:         '.paypal.com',
-    PAYPALOBJECTS:  'www.paypalobjects.com',
-    LOCALTUNNEL:    'loca.lt',
-    LOCALHOST_8000: 'localhost:8000',
-    LOCALHOST_8443: 'localhost:8443'
+    LOCALHOST:        'localhost.paypal.com',
+    PAYPAL:           '.paypal.com',
+    PAYPALOBJECTS:    'www.paypalobjects.com',
+    PAYPALOBJECTS_QA: '.paypalinc.com',
+    LOCALTUNNEL:      'loca.lt',
+    LOCALHOST_8000:   'localhost:8000',
+    LOCALHOST_8443:   'localhost:8443'
 };
 
 export const PROTOCOL = {

--- a/server/meta.jsx
+++ b/server/meta.jsx
@@ -59,7 +59,9 @@ function isLegacySDKUrl(hostname : string, pathname : string) : boolean {
         return true;
     }
 
-    if (hostname.endsWith(HOST.PAYPAL) && pathname.match(LEGACY_SDK_PATH)) {
+    const isValidHostName = hostname.endsWith(HOST.PAYPAL) || hostname.endsWith(HOST.PAYPALOBJECTS_QA);
+
+    if (isValidHostName && pathname.match(LEGACY_SDK_PATH)) {
         return true;
     }
 

--- a/server/meta.jsx
+++ b/server/meta.jsx
@@ -59,9 +59,9 @@ function isLegacySDKUrl(hostname : string, pathname : string) : boolean {
         return true;
     }
 
-    const isValidHostName = hostname.endsWith(HOST.PAYPAL) || hostname.endsWith(HOST.PAYPALOBJECTS_QA);
+    const isValidHostname = hostname.endsWith(HOST.PAYPAL) || hostname.endsWith(HOST.PAYPALOBJECTS_QA);
 
-    if (isValidHostName && pathname.match(LEGACY_SDK_PATH)) {
+    if (isValidHostname && pathname.match(LEGACY_SDK_PATH)) {
         return true;
     }
 

--- a/test/server/meta.test.js
+++ b/test/server/meta.test.js
@@ -43,6 +43,23 @@ test('should construct a valid script url with paypalobjects', () => {
     }
 });
 
+test('should construct a valid script url with checkout.js using the qa cdn', () => {
+
+    const sdkUrl = 'https://uideploy--staticcontent--7482d416a81b5--ghe.preview.dev.paypalinc.com/api/checkout.js';
+
+    const { getSDKLoader } = unpackSDKMeta(Buffer.from(JSON.stringify({
+        url: sdkUrl
+    })).toString('base64'));
+
+    const $ = cheerio.load(getSDKLoader());
+    const script = $('script[data-paypal-checkout]');
+    const src = script.attr('src');
+
+    if (src !== sdkUrl) {
+        throw new Error(`Expected script url to be ${ sdkUrl } - got ${ src }`);
+    }
+});
+
 test('should construct a valid script url with checkout.js on localhost', () => {
 
     const sdkUrl = 'http://localhost.paypal.com:8000/api/checkout.js';


### PR DESCRIPTION
This PR adds support for loading checkout.js from the QA CDN.

For example, a test page should be able to leverage the QA CDN like so:

```html
<script src="https://uideploy--staticcontent--7482d416a81b5--ghe.preview.dev.paypalinc.com/api/checkout.js" data-paypal-checkout></script>
```

This PR adds support for trusting the `.paypalinc.com` domain when validating the url stored in sdkMeta that's used for second render.