### PR TITLE
Update server-side validation to support for new .ca hosts

### DIFF
--- a/server/constants.js
+++ b/server/constants.js
@@ -1,13 +1,15 @@
 /* @flow */
 
 export const HOST = {
-    LOCALHOST:        'localhost.paypal.com',
-    PAYPAL:           '.paypal.com',
-    PAYPALOBJECTS:    'www.paypalobjects.com',
-    PAYPALOBJECTS_QA: '.paypalinc.com',
-    LOCALTUNNEL:      'loca.lt',
-    LOCALHOST_8000:   'localhost:8000',
-    LOCALHOST_8443:   'localhost:8443'
+    LOCALHOST:           'localhost.paypal.com',
+    PAYPAL:              '.paypal.com',
+    PAYPAL_CHINA:        '.paypal.cn',
+    PAYPALOBJECTS:       'www.paypalobjects.com',
+    PAYPALOBJECTS_CHINA: 'objects.paypal.cn',
+    PAYPALOBJECTS_QA:    '.paypalinc.com',
+    LOCALTUNNEL:         'loca.lt',
+    LOCALHOST_8000:      'localhost:8000',
+    LOCALHOST_8443:      'localhost:8443'
 };
 
 export const PROTOCOL = {

--- a/server/meta.jsx
+++ b/server/meta.jsx
@@ -55,11 +55,22 @@ function validateLegacySDKUrl({ pathname }) {
 }
 
 function isLegacySDKUrl(hostname : string, pathname : string) : boolean {
-    if (hostname === HOST.PAYPALOBJECTS) {
+    const legacyHostnames = [
+        HOST.PAYPALOBJECTS,
+        HOST.PAYPALOBJECTS_CHINA
+    ];
+
+    if (legacyHostnames.includes(hostname)) {
         return true;
     }
 
-    const isValidHostname = hostname.endsWith(HOST.PAYPAL) || hostname.endsWith(HOST.PAYPALOBJECTS_QA);
+    const validHostnameEndings = [
+        HOST.PAYPAL,
+        HOST.PAYPAL_CHINA,
+        HOST.PAYPALOBJECTS_QA
+    ];
+
+    const isValidHostname = validHostnameEndings.some(validHostname => hostname.endsWith(validHostname));
 
     if (isValidHostname && pathname.match(LEGACY_SDK_PATH)) {
         return true;
@@ -69,7 +80,7 @@ function isLegacySDKUrl(hostname : string, pathname : string) : boolean {
 }
 
 function isSDKUrl(hostname : string) : boolean {
-    if (hostname.endsWith(HOST.PAYPAL)) {
+    if (hostname.endsWith(HOST.PAYPAL) || hostname.endsWith(HOST.PAYPAL_CHINA)) {
         return true;
     }
 
@@ -78,7 +89,7 @@ function isSDKUrl(hostname : string) : boolean {
 
 function isLocalUrl(host : string) : boolean {
     const localUrls = [ HOST.LOCALHOST_8000, HOST.LOCALHOST_8443, HOST.LOCALTUNNEL ];
-    
+
     // eslint-disable-next-line no-process-env
     return process.env.NODE_ENV === 'development' && localUrls.some(url => host.includes(url));
 }
@@ -104,7 +115,7 @@ function validateSDKUrl(sdkUrl : string) {
         if (hostname !== HOST.LOCALHOST && protocol !== PROTOCOL.HTTPS) {
             throw new Error(`Expected protocol for sdk url to be ${ PROTOCOL.HTTPS } for host: ${ hostname } - got ${ protocol || 'undefined' }`);
         }
-        
+
         if (sdkUrl.match(/&{2,}/) || sdkUrl.match(/&$/)) {
             throw new Error(`Expected sdk url to not contain double ampersand or end in ampersand`);
         }
@@ -145,7 +156,7 @@ function getSDKScriptAttributes(sdkUrl : ?string, allAttrs : ?{ [string] : strin
         if (!hostname) {
             throw new Error(`Expected host to be passed for sdk url`);
         }
-    
+
         if (!pathname) {
             throw new Error(`Expected pathname for sdk url`);
         }
@@ -256,7 +267,7 @@ export function unpackSDKMeta(sdkMeta? : string) : SDKMeta {
             />
         ).render(html());
     };
-    
+
     return {
         getSDKLoader
     };

--- a/test/server/meta.test.js
+++ b/test/server/meta.test.js
@@ -101,7 +101,7 @@ test('should construct a script url with checkout.js on localhost without a payp
 test('should not construct a script url with checkout.js for non-supported local urls', () => {
     // eslint-disable-next-line no-process-env
     process.env.NODE_ENV = 'development';
-    
+
     const sdkUrl = 'http://not.a.supported.url:8000/api/checkout.js';
 
     let error;
@@ -306,6 +306,24 @@ test('should error out with an invalid protocol', () => {
 test('should error out with an invalid protocol in localhost', () => {
 
     const sdkUrl = 'meep://localhost.paypal.com:8000/sdk/js?client-id=foo';
+    let error;
+
+    try {
+        unpackSDKMeta(Buffer.from(JSON.stringify({
+            url: sdkUrl
+        })).toString('base64'));
+    } catch (err) {
+        error = err;
+    }
+
+    if (!error) {
+        throw new Error(`Expected error to be thrown`);
+    }
+});
+
+test('should error out with an invalid host', () => {
+
+    const sdkUrl = 'https://www.paypal.example.com/sdk/js?client-id=foo';
     let error;
 
     try {
@@ -814,6 +832,39 @@ test('should construct a valid min script url with paypalobjects on http', () =>
     const $ = cheerio.load(getSDKLoader());
     const script = $('script[data-paypal-checkout]');
     const src = script.attr('src');
+
+    if (src !== sdkUrl) {
+        throw new Error(`Expected script url to be ${ sdkUrl } - got ${ src }`);
+    }
+});
+
+test('should construct a valid script url hosted on objects.paypal.cn', () => {
+
+    const sdkUrl = 'http://www.objects.paypal.cn/api/checkout.js';
+
+    const { getSDKLoader } = unpackSDKMeta(Buffer.from(JSON.stringify({
+        url: sdkUrl
+    })).toString('base64'));
+
+    const $ = cheerio.load(getSDKLoader());
+    const script = $('script[data-paypal-checkout]');
+    const src = script.attr('src');
+
+    if (src !== sdkUrl) {
+        throw new Error(`Expected script url to be ${ sdkUrl } - got ${ src }`);
+    }
+});
+
+test('should construct a valid script url hosted on www.paypal.cn', () => {
+
+    const sdkUrl = 'https://www.paypal.cn/sdk/js?client-id=foo';
+
+    const { getSDKLoader } = unpackSDKMeta(Buffer.from(JSON.stringify({
+        url: sdkUrl
+    })).toString('base64'));
+
+    const $ = cheerio.load(getSDKLoader());
+    const src = $('script').attr('src');
 
     if (src !== sdkUrl) {
         throw new Error(`Expected script url to be ${ sdkUrl } - got ${ src }`);


### PR DESCRIPTION
This PR updates the server-side host validation rules to support:

- https://www.paypal.cn/sdk/js?client-id=foo
- http://www.objects.paypal.cn/api/checkout.js