### PR TITLE
Move domain logic to the server-side

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,8 @@ module.exports = {
         __CORRELATION_ID__: true,
         __NAMESPACE__: true,
         __COMPONENTS__: true,
-        __FUNDING_ELIGIBILITY__: true
+        __FUNDING_ELIGIBILITY__: true,
+        __PAYPAL_DOMAIN__: true,
+        __PAYPAL_API_DOMAIN__: true
     }
 };

--- a/src/declarations.js
+++ b/src/declarations.js
@@ -10,6 +10,8 @@ declare var __HOSTNAME__ : string;
 declare var __PORT__ : number;
 declare var __PATH__ : string;
 declare var __SDK_HOST__ : string;
+declare var __PAYPAL_DOMAIN__ : string;
+declare var __PAYPAL_API_DOMAIN__ : string;
 declare var __STAGE_HOST__ : ?string;
 declare var __SERVICE_STAGE_HOST__ : ?string;
 

--- a/src/domains.js
+++ b/src/domains.js
@@ -3,64 +3,8 @@
 import { ENV } from '@paypal/sdk-constants/src';
 import { getDomain, getActualDomain, isCurrentDomain } from 'cross-domain-utils/src';
 
-import { getProtocol, getHost, getStageHost, getAPIStageHost } from './global';
+import { getProtocol, getStageHost, getPayPalDomain, getPayPalAPIDomain } from './global';
 import { URI } from './config';
-
-export function getPayPalDomain() : string {
-    if (__ENV__ === ENV.LOCAL) {
-        return `${ getProtocol() }://${ getHost() }`;
-    }
-
-    if (__ENV__ === ENV.STAGE) {
-        const stageHost = getStageHost();
-
-        if (!stageHost) {
-            throw new Error(`No stage host found`);
-        }
-
-        return `${ getProtocol() }://${ stageHost }`;
-    }
-
-    if (__ENV__ === ENV.SANDBOX) {
-        return `${ getProtocol() }://www.sandbox.paypal.com`;
-    }
-
-    if (__ENV__ === ENV.PRODUCTION) {
-        return `${ getProtocol() }://www.paypal.com`;
-    }
-
-    if (__ENV__ === ENV.TEST) {
-        return `mock://www.paypal.com`;
-    }
-
-    throw new Error(`Can not get paypal domain for env: ${ __ENV__ }`);
-}
-
-export function getPayPalAPIDomain() : string {
-    if (__ENV__ === ENV.LOCAL || __ENV__ === ENV.STAGE) {
-        const apiStageHost = getAPIStageHost();
-
-        if (!apiStageHost) {
-            throw new Error(`No api stage host found`);
-        }
-
-        return `${ getProtocol() }://${ apiStageHost }`;
-    }
-
-    if (__ENV__ === ENV.SANDBOX) {
-        return `${ getProtocol() }://cors.api.sandbox.paypal.com`;
-    }
-
-    if (__ENV__ === ENV.PRODUCTION) {
-        return `${ getProtocol() }://cors.api.paypal.com`;
-    }
-
-    if (__ENV__ === ENV.TEST) {
-        return `mock://api.paypal.com`;
-    }
-
-    throw new Error(`Can not get paypal api domain for env: ${ __ENV__ }`);
-}
 
 export function getPayPalLoggerDomain() : string {
     if (__ENV__ === ENV.LOCAL) {

--- a/src/global.js
+++ b/src/global.js
@@ -31,6 +31,14 @@ export function getEnv() : $Values<typeof ENV> {
     return __ENV__;
 }
 
+export function getPayPalDomain() : string {
+    return __PAYPAL_DOMAIN__;
+}
+
+export function getPayPalAPIDomain() : string {
+    return __PAYPAL_API_DOMAIN__;
+}
+
 export function getDefaultServiceStageHost() : ?string {
     if (typeof __SERVICE_STAGE_HOST__ !== 'undefined' && __SERVICE_STAGE_HOST__ !== null) {
         return __SERVICE_STAGE_HOST__;

--- a/test/client/config.js
+++ b/test/client/config.js
@@ -1,101 +1,12 @@
 /* @flow */
 
-import { insertMockSDKScript, getPayPalDomain, getPayPalAPIDomain, getPayPalLoggerDomain, buildPayPalUrl, buildPayPalAPIUrl, getPayPalLoggerUrl } from '../../src';
+import { getPayPalLoggerDomain, buildPayPalUrl, buildPayPalAPIUrl, getPayPalLoggerUrl } from '../../src';
 
 beforeEach(() => {
     window.__ENV__ = 'test';
 });
 
 describe(`config cases`, () => {
-
-    it('should successfully get the testing paypal domain', () => {
-        const expectedPayPalDomain = 'mock://www.paypal.com';
-
-        if (getPayPalDomain() !== expectedPayPalDomain) {
-            throw new Error(`Expected paypal domain to be ${ expectedPayPalDomain }, got ${ getPayPalDomain() }`);
-        }
-    });
-
-    it('should successfully get the production paypal domain', () => {
-        window.__ENV__ = 'production';
-        const expectedPayPalDomain = 'https://www.paypal.com';
-
-        if (getPayPalDomain() !== expectedPayPalDomain) {
-            throw new Error(`Expected paypal domain to be ${ expectedPayPalDomain }, got ${ getPayPalDomain() }`);
-        }
-    });
-
-    it('should successfully get the sandbox paypal domain', () => {
-        const expectedPayPalDomain = 'https://www.sandbox.paypal.com';
-        window.__ENV__ = 'sandbox';
-
-        insertMockSDKScript({
-            query: {
-                'client-id': 'sb'
-            }
-        });
-
-        if (getPayPalDomain() !== expectedPayPalDomain) {
-            throw new Error(`Expected paypal domain to be ${ expectedPayPalDomain }, got ${ getPayPalDomain() }`);
-        }
-    });
-
-    it('should thrown error if can\'t find the requested domain', () => {
-        window.__ENV__ = 'foo';
-
-        try {
-            getPayPalDomain();
-        } catch (error) {
-            if (!error) {
-                throw new Error(`Expected paypal domain to thrown error for domain ${ __ENV__ }`);
-            }
-        }
-    });
-
-    it('should successfully get the testing paypal api domain', () => {
-        const expectedPayPalAPIDomain = 'mock://api.paypal.com';
-
-        if (getPayPalAPIDomain() !== expectedPayPalAPIDomain) {
-            throw new Error(`Expected paypal api domain to be ${ expectedPayPalAPIDomain }, got ${ getPayPalAPIDomain() }`);
-        }
-    });
-
-    it('should successfully get the sandbox paypal API domain', () => {
-        const expectedPayPalAPIDomain = 'https://cors.api.sandbox.paypal.com';
-        window.__ENV__ = 'sandbox';
-
-        insertMockSDKScript({
-            query: {
-                'client-id': 'sb'
-            }
-        });
-
-        if (getPayPalAPIDomain() !== expectedPayPalAPIDomain) {
-            throw new Error(`Expected paypal domain to be ${ expectedPayPalAPIDomain }, got ${ getPayPalAPIDomain() }`);
-        }
-    });
-
-    it('should successfully get the production paypal API domain', () => {
-        window.__ENV__ = 'production';
-        const expectedPayPalAPIDomain = 'https://cors.api.paypal.com';
-
-        if (getPayPalAPIDomain() !== expectedPayPalAPIDomain) {
-            throw new Error(`Expected paypal domain to be ${ expectedPayPalAPIDomain }, got ${ getPayPalAPIDomain() }`);
-        }
-    });
-
-    it('should thrown error if can\'t find the requested API domain', () => {
-        window.__ENV__ = 'foo';
-
-        try {
-            getPayPalAPIDomain();
-        } catch (error) {
-            if (!error) {
-                throw new Error(`Expected paypal domain to thrown error for domain ${ __ENV__ }`);
-            }
-        }
-    });
-
     it('should successfully get the paypal logger domain', () => {
         const expectedPayPalDomain = 'mock://www.paypal.com';
 

--- a/test/globals.js
+++ b/test/globals.js
@@ -12,7 +12,9 @@ export const sdkClientTestGlobals : TestGlobals = {
     __SDK_HOST__:   'test.paypal.com',
     __PATH__:       '/sdk/js',
 
-    __VERSION__:        '1.0.45',
-    __CORRELATION_ID__: 'abc123',
-    __NAMESPACE__:      'paypaltest'
+    __VERSION__:           '1.0.45',
+    __CORRELATION_ID__:    'abc123',
+    __NAMESPACE__:         'paypaltest',
+    __PAYPAL_DOMAIN__:     'mock://www.paypal.com',
+    __PAYPAL_API_DOMAIN__: 'mock://msmaster.qa.paypal.com'
 };


### PR DESCRIPTION
This PR updates `getPayPalDomain()` and `getPayPalAPIDomain()` to be global build time variables. This logic moves from the client-side to the server-side for better geo support.