### PR TITLE
support for special country locales added

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -9,6 +9,7 @@ import { COUNTRY, SDK_SETTINGS, SDK_QUERY_KEYS, INTENT, COMMIT, VAULT, CURRENCY,
 
 import { getPath, getDefaultNamespace, getSDKHost } from './global';
 import { CLIENT_ID_ALIAS } from './config';
+import { getComputedLocales } from './utils';
 
 type GetSDKScript = () => HTMLScriptElement;
 
@@ -209,12 +210,12 @@ export function getPageType() : ?string {
     return pageType.toLowerCase();
 }
 
+
 export function getLocale() : LocaleType {
     const locale = getSDKQueryParam(SDK_QUERY_KEYS.LOCALE);
 
     if (locale) {
-        const [ lang, country ] = locale.split('_');
-        return { lang, country };
+        return getComputedLocales(locale);
     }
 
     for (let { country, lang } of getBrowserLocales()) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 /* @flow */
 import type { LocaleType } from '@paypal/sdk-constants/src/';
-import { COUNTRY_LANGS } from '@paypal/sdk-constants/src';
+import { COUNTRY_LANGS, LANG } from '@paypal/sdk-constants/src';
 
 
 export function getComputedLocales(locale : string) : LocaleType {
@@ -8,8 +8,8 @@ export function getComputedLocales(locale : string) : LocaleType {
     // $FlowFixMe
     const countryLangs = COUNTRY_LANGS[country];
 
-    if (countryLangs.includes('zh_Hant')) {
-        lang = 'zh_Hant';
+    if (countryLangs.includes(LANG.ZH_HANT)) {
+        lang = LANG.ZH_HANT;
     }
 
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,6 +3,7 @@ import type { LocaleType } from '@paypal/sdk-constants/src';
 
 const SPECIAL_COUNTRY_LANG_VARIANTS = {
     'HK': 'zh_Hant'
+    'TW': 'zh_Hant'
 };
 
 export function getComputedLocales(locale : string) : LocaleType {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,16 +1,17 @@
 /* @flow */
 import type { LocaleType } from '@paypal/sdk-constants/src/';
-import { COUNTRY_LANGS, LANG } from '@paypal/sdk-constants/src';
+import { COUNTRY_LANGS, LANG, COUNTRY } from '@paypal/sdk-constants/src';
 
 export function getComputedLocales(locale : string) : LocaleType {
-    let [ lang, country ] = locale.split('_');
-    // $FlowFixMe
+    const [ _lang, _country ] = locale.split('_');
+    
+    let lang = LANG[_lang.toUpperCase()];
+    const country = COUNTRY[_country];
     const countryLangs = COUNTRY_LANGS[country];
 
     if (countryLangs.includes(LANG.ZH_HANT)) {
         lang = LANG.ZH_HANT;
     }
 
-    // $FlowFixMe
     return { lang, country };
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@
 import type { LocaleType } from '@paypal/sdk-constants/src';
 
 const SPECIAL_COUNTRY_LANG_VARIANTS = {
-    'HK': 'zh_Hant'
+    'HK': 'zh_Hant',
     'TW': 'zh_Hant'
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,6 @@
 import type { LocaleType } from '@paypal/sdk-constants/src/';
 import { COUNTRY_LANGS, LANG } from '@paypal/sdk-constants/src';
 
-
 export function getComputedLocales(locale : string) : LocaleType {
     let [ lang, country ] = locale.split('_');
     // $FlowFixMe
@@ -11,7 +10,6 @@ export function getComputedLocales(locale : string) : LocaleType {
     if (countryLangs.includes(LANG.ZH_HANT)) {
         lang = LANG.ZH_HANT;
     }
-
 
     // $FlowFixMe
     return { lang, country };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,16 +1,18 @@
 /* @flow */
-import type { LocaleType } from '@paypal/sdk-constants/src';
+import type { LocaleType } from '@paypal/sdk-constants/src/';
+import { COUNTRY_LANGS } from '@paypal/sdk-constants/src';
 
-const SPECIAL_COUNTRY_LANG_VARIANTS = {
-    'HK': 'zh_Hant',
-    'TW': 'zh_Hant'
-};
 
 export function getComputedLocales(locale : string) : LocaleType {
     let [ lang, country ] = locale.split('_');
-    if (country in SPECIAL_COUNTRY_LANG_VARIANTS) {
-        lang = SPECIAL_COUNTRY_LANG_VARIANTS[country];
+    // $FlowFixMe
+    const countryLangs = COUNTRY_LANGS[country];
+
+    if (countryLangs.includes('zh_Hant')) {
+        lang = 'zh_Hant';
     }
+
+
     // $FlowFixMe
     return { lang, country };
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,10 +3,10 @@ import type { LocaleType } from '@paypal/sdk-constants/src/';
 import { COUNTRY_LANGS, LANG, COUNTRY } from '@paypal/sdk-constants/src';
 
 export function getComputedLocales(locale : string) : LocaleType {
-    const [ _lang, _country ] = locale.split('_');
+    let [ lang, country ] = locale.split('_');
     
-    let lang = LANG[_lang.toUpperCase()];
-    const country = COUNTRY[_country];
+    lang = LANG[lang.toUpperCase()];
+    country = COUNTRY[country];
     const countryLangs = COUNTRY_LANGS[country];
 
     if (countryLangs.includes(LANG.ZH_HANT)) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,15 @@
+/* @flow */
+import type { LocaleType } from '@paypal/sdk-constants/src';
+
+const SPECIAL_COUNTRY_LANG_VARIANTS = {
+    'HK': 'zh_Hant'
+};
+
+export function getComputedLocales(locale : string) : LocaleType {
+    let [ lang, country ] = locale.split('_');
+    if (country in SPECIAL_COUNTRY_LANG_VARIANTS) {
+        lang = SPECIAL_COUNTRY_LANG_VARIANTS[country];
+    }
+    // $FlowFixMe
+    return { lang, country };
+}

--- a/test/client/script.js
+++ b/test/client/script.js
@@ -410,8 +410,8 @@ describe(`script cases`, () => {
         }
     });
 
-    it('should return computed locale when lang is zh_Hant', () => {
-        const expectedLocale = 'zh_Hant';
+    it('should return computed lang when locale is zh_Hant', () => {
+        const expectedLang = 'zh_Hant';
 
         const url = insertMockSDKScript({
             query: {
@@ -419,10 +419,9 @@ describe(`script cases`, () => {
             }
         });
 
-        const localeObject = getLocale();
-        const receivedLocal = localeObject.lang;
-        if (expectedLocale !== receivedLocal) {
-            throw new Error(`Expected locale to be ${ expectedLocale }, got ${ receivedLocal } from ${ url }`);
+        const { lang: receivedLang } = getLocale();
+        if (expectedLang !== receivedLang) {
+            throw new Error(`Expected lag to be ${ expectedLang }, got ${ receivedLang } from ${ url }`);
         }
     });
 });

--- a/test/client/script.js
+++ b/test/client/script.js
@@ -409,4 +409,20 @@ describe(`script cases`, () => {
             throw new Error(`Expected locale to be ${ expectedLocale }, got ${ receivedLocale }`);
         }
     });
+
+    it('should return computed locale when lang is zh_Hant', () => {
+        const expectedLocale = 'zh_Hant';
+
+        const url = insertMockSDKScript({
+            query: {
+                'locale': 'zh_HK'
+            }
+        });
+
+        const localeObject = getLocale();
+        const receivedLocal = localeObject.lang;
+        if (expectedLocale !== receivedLocal) {
+            throw new Error(`Expected locale to be ${ expectedLocale }, got ${ receivedLocal } from ${ url }`);
+        }
+    });
 });


### PR DESCRIPTION
## Description

- Special Language variants are now supported and are handled as new entire languages. Such strings contain no only the specific country language, but  the country as well, a detailed explanation [here](https://github.com/paypal/paypal-sdk-constants/pull/55) 

## ScreenShots
![image](https://user-images.githubusercontent.com/17114924/139479320-4191b316-5b70-44bd-8368-1f10554c8363.png)

## Related PR's

- https://github.com/paypal/paypal-sdk-constants/pull/55
- https://github.com/paypal/paypal-identity-components/pull/14
- https://github.com/paypal/paypal-checkout-components/pull/1637

## Depends on:

- https://github.paypal.com/Checkout-R/clientsdknodeweb/pull/304
