### PR TITLE
Add failing test for merchant-id emails

### DIFF
--- a/server/meta.jsx
+++ b/server/meta.jsx
@@ -15,6 +15,9 @@ type SDKMeta = {|
     getSDKLoader : (options? : {| baseURL? : string, nonce? : string |}) => string
 |};
 
+const emailRegex = /^.+@.+$/;
+const emailMaxLengthRegex = /^.{1,64}$/
+
 function validatePaymentsSDKUrl({ pathname, query, hash }) {
 
     if (pathname !== SDK_PATH) {
@@ -37,9 +40,22 @@ function validatePaymentsSDKUrl({ pathname, query, hash }) {
             throw new TypeError(`Unexpected non-string key for sdk url: ${ key }`);
         }
 
-        if (!val.match(/^[a-zA-Z0-9_,-@.]+$/) && !val.match(/^\*$/)) {
+        if (!val.match(/^[a-zA-Z0-9+_,-@.]+$/) && !val.match(/^\*$/)) {
             throw new Error(`Unexpected characters in query key for sdk url: ${ key }=${ val }`);
         }
+
+        if (key === SDK_QUERY_KEYS.MERCHANT_ID) {
+            const merchantValues = val.split(",");
+            Array.from(merchantValues).forEach(aMerchantValue => {
+                if (!emailMaxLengthRegex.test(aMerchantValue)) {
+                    throw new Error(`Email is too long: ${aMerchantValue}`)
+                }
+                if (aMerchantValue.includes("@") && !emailRegex.test(aMerchantValue)) {
+                    throw new Error(`Malformed. merchant email: ${aMerchantValue}`);
+                }
+            });
+        }
+
     }
 
     if (hash) {

--- a/test/server/meta.test.js
+++ b/test/server/meta.test.js
@@ -218,6 +218,56 @@ test('should unpack a valid sdk meta bundle with multiple components', () => {
     }
 });
 
+test('should unpack a valid sdk meta bundle with multiple merchant-id email addresses', () => {
+    const emails = [
+        'test@gmail.com',
+        'foo@bar.com',
+        'test@test.org.uk',
+        'test-test@test.com',
+        'test.test@test.com',
+        'test@test@test.com'
+    ];
+
+    const sdkUrl = `https://www.paypal.com/sdk/js?client-id=foo&merchant-id=${ emails.map(anEmail => encodeURIComponent(anEmail)).join(',') }`;
+
+    const { getSDKLoader } = unpackSDKMeta(Buffer.from(JSON.stringify({
+        url: sdkUrl
+    })).toString('base64'));
+
+    const $ = cheerio.load(getSDKLoader());
+    const src = $('script').attr('src');
+
+    if (src !== sdkUrl) {
+        throw new Error(`Expected script url to be ${ sdkUrl } - got ${ src }`);
+    }
+});
+
+test('should error out from invalid merchant-id email addresses', () => {
+    const emails = [
+        '@',
+        '@io',
+        '@test.com',
+        'verylongemail-verylongemail-verylongemail-verylongemail@alongdomain.com'
+    ];
+
+    emails.forEach(email => {
+        const sdkUrl = `https://www.paypal.com/sdk/js?client-id=foo&merchant-id=${ email }`;
+        let error;
+
+        try {
+            unpackSDKMeta(Buffer.from(JSON.stringify({
+                url: sdkUrl
+            })).toString('base64'));
+        } catch (err) {
+            error = err;
+        }
+
+        if (!error) {
+            throw new Error(`Expected error to be thrown for ${ sdkUrl }`);
+        }
+    });
+});
+
 test('should construct a valid script url with multiple merchant ids', () => {
 
     const sdkUrl = 'https://www.paypal.com/sdk/js?client-id=foo';


### PR DESCRIPTION
The `merchant-id` query string parameter accepts an email address or an id. We have a support ticket for adding support for email addresses containing characters like `+`: `'test1+test2@foo.com'`. Currently this email address throws a validation error: https://www.paypal.com/sdk/js?client-id=sb&merchant-id=test1+test2@foo.com

I researched this a bit and it looks like using `url.parse(urlString, true)` drops the `+` causing it to be `'test1 test2@foo.com'`. 

Perhaps we can use a custom escape function with `querystring.parse()` to best solve. https://nodejs.org/api/querystring.html#querystringparsestr-sep-eq-options