### PR TITLE
fix locales issue

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -9,7 +9,7 @@ export function getComputedLocales(locale : string) : LocaleType {
     country = COUNTRY[country];
     const countryLangs = COUNTRY_LANGS[country];
 
-    if (countryLangs && countryLangs.includes(LANG.ZH_HANT)) {
+    if (countryLangs && countryLangs.includes(LANG.ZH_HANT) && lang === LANG.ZH) {
         lang = LANG.ZH_HANT;
     }
 

--- a/test/client/script.js
+++ b/test/client/script.js
@@ -410,12 +410,27 @@ describe(`script cases`, () => {
         }
     });
 
-    it('should return computed lang when locale is zh_Hant', () => {
+    it('should return computed lang when locale is zh_HK', () => {
         const expectedLang = 'zh_Hant';
 
         const url = insertMockSDKScript({
             query: {
                 'locale': 'zh_HK'
+            }
+        });
+
+        const { lang: receivedLang } = getLocale();
+        if (expectedLang !== receivedLang) {
+            throw new Error(`Expected lag to be ${ expectedLang }, got ${ receivedLang } from ${ url }`);
+        }
+    });
+
+    it('should return the right computed lang when locale is en_Hk', () => {
+        const expectedLang = 'en';
+
+        const url = insertMockSDKScript({
+            query: {
+                'locale': 'en_HK'
             }
         });
 

--- a/test/client/script.js
+++ b/test/client/script.js
@@ -430,7 +430,7 @@ describe(`script cases`, () => {
 
         const url = insertMockSDKScript({
             query: {
-                'locale': 'en_HK'
+                'locale': `${ expectedLang }_HK`
             }
         });
 


### PR DESCRIPTION
# Description

Previously, any country that had `zh_Hant` as one of its available languages, the logic returned always `zh_Hant` as lang, ignoring variables as `en` or other supported languages. This fix solves that


- [Jira Ticket](https://engineering.paypalcorp.com/jira/browse/DTPPSDK-193)
- has to do with:  https://github.paypal.com/Checkout-R/clientsdknodeweb/pull/304

## Related PRs

- https://github.paypal.com/Checkout-R/clientsdknodeweb/pull/306
- https://github.com/paypal/paypal-checkout-components/pull/1789