### PR TITLE
Eslint rule for compatibility with IE11

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,9 @@
 
 module.exports = {
     'extends': './node_modules/grumbler-scripts/config/.eslintrc-browser.js',
-
+    rules: {
+        'dont-use-includes': 'error',
+    },
     globals: {
         __STAGE__: true,
         __VERSION__: true,

--- a/lint-rules/dont-use-includes.js
+++ b/lint-rules/dont-use-includes.js
@@ -1,0 +1,14 @@
+module.exports = {
+    create(context) {
+        return {
+            CallExpression(node) {
+                if (node.callee.property && node.callee.property.name === 'includes') {
+                    context.report({
+                        node: node,
+                        message: 'Please, use array.indexOf() !== -1 instead of array.includes() for compatibility with IE11'
+                    })
+                }
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "flow": "flow",
     "flow-typed": "rm -rf ./flow-typed && flow-typed install",
     "karma": "cross-env NODE_ENV=test babel-node --plugins=transform-es2015-modules-commonjs ./node_modules/.bin/karma start",
-    "lint": "eslint src/ server/ test/ *.js",
+    "lint": "eslint --rulesdir lint-rules src/ server/ test/ *.js",
     "reinstall": "rimraf flow-typed && rimraf node_modules && npm install && flow-typed install",
     "release": "./publish.sh",
     "release:major": "./publish.sh major",

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -1,8 +1,10 @@
 /* @flow */
 
 module.exports = {
-    'extends': './node_modules/grumbler-scripts/config/.eslintrc-browser.js',
-
+    'extends': '../node_modules/grumbler-scripts/config/.eslintrc-browser.js',
+    rules: {
+        'dont-use-includes': 'error',
+    },
     globals: {
         __STAGE__: true,
         __VERSION__: true,


### PR DESCRIPTION
Creating an ESLint rule for not permiting the function `Array.includes()` inside the folder `src/`. Notice that `/server` and `/test` are not affected by this rule.

This change is needed for compatibility with IE11 (to avoid future problems) 