### PR TITLE
Enable global variable to force Logger URL set to PayPal domain

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,7 @@ module.exports = {
         __COMPONENTS__: true,
         __FUNDING_ELIGIBILITY__: true,
         __PAYPAL_DOMAIN__: true,
-        __FORCE_PAYPAL_DOMAIN__: true,
+        __FORCE_PAYPAL_DOMAIN_LOGGER__: true,
         __PAYPAL_API_DOMAIN__: true
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
         __COMPONENTS__: true,
         __FUNDING_ELIGIBILITY__: true,
         __PAYPAL_DOMAIN__: true,
+        __FORCE_PAYPAL_DOMAIN__: true,
         __PAYPAL_API_DOMAIN__: true
     }
 };

--- a/src/declarations.js
+++ b/src/declarations.js
@@ -13,7 +13,7 @@ declare var __PORT__ : number;
 declare var __PATH__ : string;
 declare var __SDK_HOST__ : string;
 declare var __PAYPAL_DOMAIN__ : string;
-declare var __FORCE_PAYPAL_DOMAIN__: boolean;
+declare var __FORCE_PAYPAL_DOMAIN_LOGGER__: boolean;
 declare var __PAYPAL_API_DOMAIN__ : string;
 declare var __STAGE_HOST__ : ?string;
 declare var __SERVICE_STAGE_HOST__ : ?string;

--- a/src/declarations.js
+++ b/src/declarations.js
@@ -13,6 +13,7 @@ declare var __PORT__ : number;
 declare var __PATH__ : string;
 declare var __SDK_HOST__ : string;
 declare var __PAYPAL_DOMAIN__ : string;
+declare var __FORCE_PAYPAL_DOMAIN__: boolean;
 declare var __PAYPAL_API_DOMAIN__ : string;
 declare var __STAGE_HOST__ : ?string;
 declare var __SERVICE_STAGE_HOST__ : ?string;

--- a/src/domains.js
+++ b/src/domains.js
@@ -37,7 +37,7 @@ export function buildPayPalAPIUrl(path : string = '') : string {
 }
 
 export function getPayPalLoggerUrl() : string {
-    return __FORCE_PAYPAL_DOMAIN__ ?
+    return __FORCE_PAYPAL_DOMAIN_LOGGER__ ?
         `${ getPayPalDomain() }${ URI.LOGGER }` :
         buildPayPalUrl(URI.LOGGER);
 }

--- a/src/domains.js
+++ b/src/domains.js
@@ -37,7 +37,9 @@ export function buildPayPalAPIUrl(path : string = '') : string {
 }
 
 export function getPayPalLoggerUrl() : string {
-    return buildPayPalUrl(URI.LOGGER);
+    return __FORCE_PAYPAL_DOMAIN__ ?
+        `${ getPayPalDomain() }${ URI.LOGGER }` :
+        buildPayPalUrl(URI.LOGGER);
 }
 
 export function getAuthAPIUrl() : string {

--- a/test/client/config.js
+++ b/test/client/config.js
@@ -34,6 +34,7 @@ describe(`config cases`, () => {
     });
 
     it('should successfully build a paypal logger url', () => {
+        console.karma('@@@', __FORCE_PAYPAL_DOMAIN__);
         const expectedPayPalUrl = `${ window.location.protocol }//${ window.location.host }/xoplatform/logger/api/logger`;
         const result = getPayPalLoggerUrl();
 

--- a/test/client/config.js
+++ b/test/client/config.js
@@ -34,7 +34,6 @@ describe(`config cases`, () => {
     });
 
     it('should successfully build a paypal logger url', () => {
-        console.karma('@@@', __FORCE_PAYPAL_DOMAIN__);
         const expectedPayPalUrl = `${ window.location.protocol }//${ window.location.host }/xoplatform/logger/api/logger`;
         const result = getPayPalLoggerUrl();
 

--- a/test/client/domains.js
+++ b/test/client/domains.js
@@ -1,11 +1,15 @@
 /* @flow */
 
-import { getPayPalDomainRegex } from '../../src';
+import { getPayPalDomainRegex, getPayPalLoggerUrl } from '../../src';
 
 beforeEach(() => {
     window.__ENV__ = 'test';
 });
 describe(`domains test`, () => {
+    before(() => {
+        window.__FORCE_PAYPAL_DOMAIN__ = true;
+    });
+
     it('should successfully match valid domain', () => {
 
         const validDomains = [
@@ -36,6 +40,15 @@ describe(`domains test`, () => {
             if (domain.match(getPayPalDomainRegex())) {
                 throw new Error(`${ domain } must not match the regex`);
             }
+        }
+    });
+
+    it('should successfully get logger url forced to paypal domain', () => {
+        const expectedPayPalUrl = `${ __PAYPAL_DOMAIN__ }/xoplatform/logger/api/logger`;
+        const result = getPayPalLoggerUrl();
+
+        if (result !== expectedPayPalUrl) {
+            throw new Error(`Expected paypal logger url to be ${ expectedPayPalUrl }, got ${ result }`);
         }
     });
 });

--- a/test/client/domains.js
+++ b/test/client/domains.js
@@ -7,7 +7,7 @@ beforeEach(() => {
 });
 describe(`domains test`, () => {
     before(() => {
-        window.__FORCE_PAYPAL_DOMAIN__ = true;
+        window.__FORCE_PAYPAL_DOMAIN_LOGGER__ = true;
     });
 
     it('should successfully match valid domain', () => {

--- a/test/globals.js
+++ b/test/globals.js
@@ -16,6 +16,6 @@ export const sdkClientTestGlobals : TestGlobals = {
     __CORRELATION_ID__:    'abc123',
     __NAMESPACE__:         'paypaltest',
     __PAYPAL_DOMAIN__:     'mock://www.paypal.com',
-    __FORCE_PAYPAL_DOMAIN__: false,
+    __FORCE_PAYPAL_DOMAIN_LOGGER__: false,
     __PAYPAL_API_DOMAIN__: 'mock://msmaster.qa.paypal.com'
 };

--- a/test/globals.js
+++ b/test/globals.js
@@ -16,5 +16,6 @@ export const sdkClientTestGlobals : TestGlobals = {
     __CORRELATION_ID__:    'abc123',
     __NAMESPACE__:         'paypaltest',
     __PAYPAL_DOMAIN__:     'mock://www.paypal.com',
+    __FORCE_PAYPAL_DOMAIN__: false,
     __PAYPAL_API_DOMAIN__: 'mock://msmaster.qa.paypal.com'
 };


### PR DESCRIPTION
### Description
This PR contains a new global variable to force Logger to use the PayPal domain and not use the actual domain when `__TEST__` and `__WEB__` variables are `true`. The source of the problem is this function `getPayPalLoggerUrl` after called `buildPayPalUrl`. If the global variables `__TEST__` and `__WEB__` are `true` the Logger will use the current domain all the time. This is a new requirement after the`Geo` integration.

### Why are we making these changes?
Please check out this Jira ticket form for more information: [JIRA](https://engineering.paypalcorp.com/jira/browse/DTPPSDK-514)


### Reproduction Steps
This Jira ticket contains an explanation of the problem: [JIRA](https://engineering.paypalcorp.com/jira/browse/DTPPSDK-514)