### PR TITLE
Improve domain validation logic

### DIFF
--- a/server/meta.jsx
+++ b/server/meta.jsx
@@ -80,10 +80,6 @@ function isLegacySDKUrl(hostname : string, pathname : string) : boolean {
 }
 
 function isSDKUrl(hostname : string) : boolean {
-    // if (hostname.match(/https:\/\/[a-z0-9\.]+.paypal.(com|cn)/)) {
-    //     return true;
-    // }
-
     if (hostname.endsWith(HOST.PAYPAL) || hostname.endsWith(HOST.PAYPAL_CHINA)) {
         return true;
     }
@@ -111,6 +107,12 @@ function validateSDKUrl(sdkUrl : string) {
 
     if (!sdkUrl.startsWith(PROTOCOL.HTTP) && !sdkUrl.startsWith(PROTOCOL.HTTPS)) {
         throw new Error(`Expected protocol for sdk url to be ${ PROTOCOL.HTTP } or ${ PROTOCOL.HTTPS } for host: ${ hostname } - got ${ protocol || 'undefined' }`);
+    }
+
+    const hostnameMatchResults = hostname.match(/[a-z0-9\.\-]+/);
+
+    if (!hostnameMatchResults || hostnameMatchResults[0] !== hostname) {
+        throw new Error(`Expected a valid host: ${ hostname }`);
     }
 
     if (isLegacySDKUrl(hostname, pathname)) {

--- a/server/meta.jsx
+++ b/server/meta.jsx
@@ -109,7 +109,7 @@ function validateSDKUrl(sdkUrl : string) {
         throw new Error(`Expected pathname for sdk url`);
     }
 
-    if (protocol !== PROTOCOL.HTTP && protocol !== PROTOCOL.HTTPS) {
+    if (!sdkUrl.startsWith(PROTOCOL.HTTP) && !sdkUrl.startsWith(PROTOCOL.HTTPS)) {
         throw new Error(`Expected protocol for sdk url to be ${ PROTOCOL.HTTP } or ${ PROTOCOL.HTTPS } for host: ${ hostname } - got ${ protocol || 'undefined' }`);
     }
 

--- a/server/meta.jsx
+++ b/server/meta.jsx
@@ -80,6 +80,10 @@ function isLegacySDKUrl(hostname : string, pathname : string) : boolean {
 }
 
 function isSDKUrl(hostname : string) : boolean {
+    // if (hostname.match(/https:\/\/[a-z0-9\.]+.paypal.(com|cn)/)) {
+    //     return true;
+    // }
+
     if (hostname.endsWith(HOST.PAYPAL) || hostname.endsWith(HOST.PAYPAL_CHINA)) {
         return true;
     }

--- a/test/server/meta.test.js
+++ b/test/server/meta.test.js
@@ -870,3 +870,39 @@ test('should construct a valid script url hosted on www.paypal.cn', () => {
         throw new Error(`Expected script url to be ${ sdkUrl } - got ${ src }`);
     }
 });
+
+test('should error when the script url does not start with "https://"', () => {
+    const sdkUrl = '\uFEFFhttps://www.paypal.com/sdk/js?client-id=foo';
+
+    let error;
+
+    try {
+        unpackSDKMeta(Buffer.from(JSON.stringify({
+            url: sdkUrl
+        })).toString('base64'));
+    } catch (err) {
+        error = err;
+    }
+
+    if (!error) {
+        throw new Error(`Expected error to be thrown`);
+    }
+});
+
+test('should error when the script subdomain contains a backslash', () => {
+    const sdkUrl = 'https://\uff3cU0022\uff3cU003E\uff3cU003C\uff3cU002Fscript\uff3cU003E\uff3cU003Ciframe\uff3cU0020srcdoc\uff3cU003D\uff3cU0027.www.paypal.com/sdk/js?client-id=foo';
+
+    let error;
+
+    try {
+        unpackSDKMeta(Buffer.from(JSON.stringify({
+            url: sdkUrl
+        })).toString('base64'));
+    } catch (err) {
+        error = err;
+    }
+
+    if (!error) {
+        throw new Error(`Expected error to be thrown`);
+    }
+});

--- a/test/server/meta.test.js
+++ b/test/server/meta.test.js
@@ -871,8 +871,9 @@ test('should construct a valid script url hosted on www.paypal.cn', () => {
     }
 });
 
-test('should error when the script url does not start with "https://"', () => {
+test('should error when the script url does not start with "https://" or "http://"', () => {
     const sdkUrl = '\uFEFFhttps://www.paypal.com/sdk/js?client-id=foo';
+    const sdkUrlLegacy = '\uFEFFhttp://www.paypalobjects.com/api/checkout.js';
 
     let error;
 
@@ -887,9 +888,21 @@ test('should error when the script url does not start with "https://"', () => {
     if (!error) {
         throw new Error(`Expected error to be thrown`);
     }
+
+    try {
+        unpackSDKMeta(Buffer.from(JSON.stringify({
+            url: sdkUrlLegacy
+        })).toString('base64'));
+    } catch (err) {
+        error = err;
+    }
+
+    if (!error) {
+        throw new Error(`Expected error to be thrown`);
+    }
 });
 
-test('should error when the script subdomain contains a backslash', () => {
+test('should error when invalid characters are found in the subdomain - we allow letters, numbers, . and -', () => {
     const sdkUrl = 'https://\uff3cU0022\uff3cU003E\uff3cU003C\uff3cU002Fscript\uff3cU003E\uff3cU003Ciframe\uff3cU0020srcdoc\uff3cU003D\uff3cU0027.www.paypal.com/sdk/js?client-id=foo';
 
     let error;


### PR DESCRIPTION
This PR improves the `validateSDKUrl()` server-side logic with the following changes:
1. Ensures the protocol really starts with http or https. The Node url.parse() function seems to ignore certain prefixes. In the screenshot below, note how the original url string starts with `/uFEFF` but the parsed protocol  shows `https:`
<img width="1797" alt="Screen Shot 2022-01-24 at 4 31 27 PM" src="https://user-images.githubusercontent.com/534034/150880352-f451b08e-84ff-4d69-a9d0-c2ed10e4bd35.png">

2. Prevent backslashes and other potentially harmful characters from being included in the subdomain of the url.
