### PR TITLE
Fix bug with merchant-id validation logic

### DIFF
--- a/server/meta.jsx
+++ b/server/meta.jsx
@@ -43,7 +43,8 @@ function validatePaymentsSDKUrl({ pathname, query, hash }) {
             throw new Error(`Unexpected characters in query key for sdk url: ${ key }=${ val }`);
         }
 
-        if (key === SDK_QUERY_KEYS.MERCHANT_ID) {
+        // assume merchant-id values with an @ character are email addresses
+        if (key === SDK_QUERY_KEYS.MERCHANT_ID && val.includes('@')) {
             const merchantValues = val.split(",");
             merchantValues.forEach(merchantValue => {
                 if (merchantValue.length > 320) {

--- a/test/server/meta.test.js
+++ b/test/server/meta.test.js
@@ -264,8 +264,7 @@ test('should error out from invalid merchant-id email addresses', () => {
         '@',
         '@io',
         '@test.com',
-        'name@',
-        'no_at_sign'
+        'name@'
     ];
 
     emails.forEach(email => {

--- a/test/server/meta.test.js
+++ b/test/server/meta.test.js
@@ -329,6 +329,28 @@ test('should construct a valid script url with multiple merchant ids', () => {
     }
 });
 
+test('should construct a valid script url with a single merchant id in the url', () => {
+
+    const merchantId = 'UYEGJNV75RAJQ';
+    const sdkUrl = `https://www.paypal.com/sdk/js?client-id=foo&merchant-id=${ merchantId }`;
+
+    const { getSDKLoader } = unpackSDKMeta(Buffer.from(JSON.stringify({
+        url:   sdkUrl
+    })).toString('base64'));
+
+    const $ = cheerio.load(getSDKLoader());
+    const src = $('script').attr('src');
+    const dataMerchantId = $('script').attr('data-merchant-id');
+
+    if (src !== sdkUrl) {
+        throw new Error(`Expected script url to be ${ sdkUrl } - got ${ src }`);
+    }
+
+    if (dataMerchantId !== merchantId) {
+        throw new Error(`Expected data-merchant-id to be ${ merchantId } - got ${ dataMerchantId }`);
+    }
+});
+
 test('should construct a valid script url without invalid attributes', () => {
 
     const sdkUrl = 'https://www.paypal.com/sdk/js?client-id=foo';

--- a/test/server/meta.test.js
+++ b/test/server/meta.test.js
@@ -340,14 +340,9 @@ test('should construct a valid script url with a single merchant id in the url',
 
     const $ = cheerio.load(getSDKLoader());
     const src = $('script').attr('src');
-    const dataMerchantId = $('script').attr('data-merchant-id');
 
     if (src !== sdkUrl) {
         throw new Error(`Expected script url to be ${ sdkUrl } - got ${ src }`);
-    }
-
-    if (dataMerchantId !== merchantId) {
-        throw new Error(`Expected data-merchant-id to be ${ merchantId } - got ${ dataMerchantId }`);
     }
 });
 


### PR DESCRIPTION
This PR fixes an issue where the merchant-id validation logic was assuming every merchant-id value was an email. This only applies the email validation to values containing an `@` character.