### PR TITLE
chrore: enhance the coverage report in Codecov

### DIFF
--- a/codedov.yml
+++ b/codedov.yml
@@ -1,0 +1,32 @@
+coverage:
+  status:
+    projects:
+      default:
+        target: 50%
+    patch:
+      client: 
+        target: 50%
+        threshold: 0.01%
+        flags:
+          - client
+      server:
+        target: 50%
+        threshold: 0.01%
+        flags:
+          - server
+
+comments:
+  layout: "diff, flags, files"
+
+flags: 
+  client:
+    carryforward: false
+    paths:
+      - src
+  server:
+    carryforward: false
+    paths:
+      - server
+
+github_checks:
+  annotations: true


### PR DESCRIPTION
### Description
The PR enhance the codecov report testing coverage creating two different flags, one for the client-side and the other for the server-side

### Why are we making these changes?
To split the test coverage report target in two paths, the client-side and the server-side