### PR TITLE
feat(codecov): enhance the codecov report

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,26 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 50%
+      client: 
+        target: 50%
+        threshold: 1%
+        flags:
+          - client
+      server:
+        target: 100%
+        threshold: 1%
+        flags:
+          - server
+
+comment:
+  layout: "diff, flags, files"
+
+flags: 
+  client:
+    paths:
+      - src
+  server:
+    paths:
+      - server

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "webpack": "babel-node --plugins=transform-es2015-modules-commonjs ./node_modules/.bin/webpack --progress",
     "jest": "jest test/server --env=node --no-cache --collectCoverageFrom='server/' --coverage --verbose --runInBand --silent=false",
     "prepublishOnly": "npm run babel",
-    "postpublish": "rm -rf ./server && git checkout ./server"
+    "postpublish": "rm -rf ./server && git checkout ./server",
+    "validate-codecov": "curl --data-binary @.github/codecov.yml https://codecov.io/validate"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
### Description
The PR enhance the codecov report testing coverage creating two different flags, one for the client-side and the other for the server-side

### Why are we making these changes?
To split the test coverage report target in two paths, the client-side and the server-side