### PR TITLE
Fix log

### DIFF
--- a/src/experiment.js
+++ b/src/experiment.js
@@ -29,7 +29,12 @@ export function createExperiment(name : string, sample : number) : Experiment {
         },
 
         logCheckpoint({ treatment, checkpoint, payload }) {
-            logger.info(`${ name }_${ treatment }_${ checkpoint }`, payload);
+            if (treatment.indexOf(name) !== -1) {
+                logger.info(`${ treatment }_${ checkpoint }`, payload);
+            } else {
+                logger.info(`${ name }_${ treatment }_${ checkpoint }`, payload);
+            }
+            
             logger.flush();
         }
     });

--- a/src/experiment.js
+++ b/src/experiment.js
@@ -2,13 +2,14 @@
 
 
 import { experiment, type Experiment } from '@krakenjs/belter/src';
+import { type LoggerType } from '@krakenjs/beaver-logger/src';
 import { FPTI_KEY } from '@paypal/sdk-constants/src';
 
 import { FPTI_STATE, FPTI_TRANSITION } from './constants';
 import { getLogger } from './logger';
 
-export function createExperiment(name : string, sample : number) : Experiment {
-    const logger = getLogger();
+export function createExperiment(name : string, sample : number, logger? : LoggerType) : Experiment {
+    const log = logger || getLogger();
 
     return experiment({
         name,
@@ -24,18 +25,18 @@ export function createExperiment(name : string, sample : number) : Experiment {
                 ...payload
             };
 
-            logger.track(fullPayload);
-            logger.flush();
+            log.track(fullPayload);
+            log.flush();
         },
 
         logCheckpoint({ treatment, checkpoint, payload }) {
             if (treatment.indexOf(name) !== -1) {
-                logger.info(`${ treatment }_${ checkpoint }`, payload);
+                log.info(`${ treatment }_${ checkpoint }`, payload);
             } else {
-                logger.info(`${ name }_${ treatment }_${ checkpoint }`, payload);
+                log.info(`${ name }_${ treatment }_${ checkpoint }`, payload);
             }
-            
-            logger.flush();
+
+            log.flush();
         }
     });
 }


### PR DESCRIPTION
## Description
Current experiment helper logs the name twice in CAL log.  This PR checks to see if name already exists in treatment name and prevents duplication if present. Also allows passing in a logger instance to keep logging consistent in the context the experiment is in.

### OLD Log
![image](https://user-images.githubusercontent.com/1324812/174819891-8f83f6d3-ffef-4d41-b744-c50abecb1949.png)

### NEW Log
<img width="1094" alt="image" src="https://user-images.githubusercontent.com/1324812/174822275-96d5035d-3212-4a17-90b8-cd1bfceb56ca.png">

