### PR TITLE
feat: upgrade to grumbler-scripts 8

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,7 @@
 /* @flow */
 
 module.exports = {
-  extends:
-    "./node_modules/@krakenjs/grumbler-scripts/config/.eslintrc-browser.js",
+  extends: "@krakenjs/eslint-config-grumbler/eslintrc-browser",
 
   globals: {
     __STAGE__: true,

--- a/.flowconfig
+++ b/.flowconfig
@@ -13,6 +13,5 @@
 [libs]
 flow-typed
 src/declarations.js
-node_modules/@krakenjs/grumbler-scripts/declarations.js
 [options]
 module.name_mapper='^src\(.*\)$' -> '<PROJECT_ROOT>/src/\1'

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,5 +2,5 @@
 /* eslint import/no-commonjs: off */
 
 module.exports = {
-  extends: "@krakenjs/grumbler-scripts/config/.babelrc-node",
+  extends: "@krakenjs/babel-config-grumbler/babel-node",
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,5 +2,5 @@
 /* eslint import/no-commonjs: off */
 
 module.exports = {
-  extends: "@krakenjs/babel-config-grumbler/babel-node",
+  extends: "@krakenjs/babel-config-grumbler/babelrc-node",
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,7 +1,7 @@
 /* @flow */
 /* eslint import/no-default-export: off */
 
-import { getKarmaConfig } from "@krakenjs/grumbler-scripts/config/karma.conf";
+import { getKarmaConfig } from "@krakenjs/karma-config-grumbler";
 
 import { WEBPACK_CONFIG_TEST } from "./webpack.config";
 

--- a/package.json
+++ b/package.json
@@ -62,15 +62,18 @@
     "bowser": "^2.0.0"
   },
   "devDependencies": {
-    "@krakenjs/grumbler-scripts": "^7.0.0",
+    "@krakenjs/grumbler-scripts": "^8.0.1",
     "@krakenjs/sync-browser-mocks": "^3.0.0",
     "babel-core": "7.0.0-bridge.0",
     "cheerio": "1.0.0-rc.9",
+    "cross-env": "^7.0.3",
     "esdoc": "1.1.0",
     "esdoc-flow-type-plugin": "1.1.0",
     "esdoc-standard-plugin": "1.0.0",
     "flow-bin": "0.155.0",
+    "flow-typed": "^3.8.0",
     "husky": "^8.0.1",
+    "jest": "^29.3.1",
     "lint-staged": "^13.0.3",
     "mocha": "^4.1.0",
     "prettier": "2.7.1"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "bowser": "^2.0.0"
   },
   "devDependencies": {
-    "@krakenjs/grumbler-scripts": "^8.0.1",
+    "@krakenjs/grumbler-scripts": "^8.0.4",
     "@krakenjs/sync-browser-mocks": "^3.0.0",
     "babel-core": "7.0.0-bridge.0",
     "cheerio": "1.0.0-rc.9",

--- a/src/declarations.js
+++ b/src/declarations.js
@@ -21,6 +21,7 @@ declare var __TEST__: boolean;
 declare var __ENV__: $Values<typeof ENV>;
 declare var __DEBUG__: boolean;
 declare var __STAGE__: boolean;
+declare var __WEB__: boolean;
 
 declare var __VERSION__: string;
 declare var __CORRELATION_ID__: string;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,3 +12,5 @@ export const WEBPACK_CONFIG_TEST: WebpackConfig = getWebpackConfig({
     ...sdkClientTestGlobals,
   },
 });
+
+export default [WEBPACK_CONFIG_TEST];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,4 +13,5 @@ export const WEBPACK_CONFIG_TEST: WebpackConfig = getWebpackConfig({
   },
 });
 
+// eslint-disable-next-line import/no-default-export
 export default [WEBPACK_CONFIG_TEST];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,8 @@
 /* @flow */
 /* eslint import/no-nodejs-modules: off */
 
-import type { WebpackConfig } from "@krakenjs/grumbler-scripts/config/types";
-import { getWebpackConfig } from "@krakenjs/grumbler-scripts/config/webpack.config";
+import type { WebpackConfig } from "@krakenjs/webpack-config-grumbler/index.flow";
+import { getWebpackConfig } from "@krakenjs/webpack-config-grumbler";
 
 import { sdkClientTestGlobals } from "./test/globals";
 


### PR DESCRIPTION
[DTPPSDK-941](https://engineering.paypalcorp.com/jira/browse/DTPPSDK-941)

* Migrated to grumbler scripts v8.  
* Added `flow-typed`, `jest`, and `cross-env` as explicit dev-dependencies.  
* Added declaration for `__WEB__` to resolve flow errors.