### PR TITLE
Add sendCountMetric to logger

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -22,11 +22,11 @@ export const getLogger: GetLogger = memoize(() => {
 
 export const sendCountMetric = ({
   dimensions,
-  event = "unused",
+  event,
   name,
   value = 1,
 }: {|
-  event?: string,
+  event: string,
   name: string,
   value?: number,
   dimensions: {


### PR DESCRIPTION
This PR adds an exact copy of `sendCountMetric` here centrally, it was initially added in SPB but is being used in SDK repos. After this is in we can remove the one temporarily added in checkout-components