### PR TITLE
add DPoP encoding utils

### DIFF
--- a/src/dpop.js
+++ b/src/dpop.js
@@ -1,6 +1,5 @@
 /* @flow */
-
-import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
+/* eslint-disable promise/no-native, no-restricted-globals */
 
 export const stringToBytes = (string: string): Uint8Array => {
   // eslint-disable-next-line compat/compat
@@ -23,11 +22,11 @@ export const base64decodeUrlSafe = (string: string): string => {
   return atob(string.replace(/-/g, "+").replace(/_/g, "/"));
 };
 
-export const sha256 = (string: string): ZalgoPromise<string> => {
+export const sha256 = async (string: string): Promise<string> => {
   const bytes = stringToBytes(string);
-  return window.crypto.subtle.digest("sha-256", bytes).then((digest) => {
-    const binaryString = bytesToString(new Uint8Array(digest));
-    const encodedBinaryString = base64encodeUrlSafe(binaryString);
-    return ZalgoPromise.resolve(encodedBinaryString);
-  });
+  const digest = await window.crypto.subtle.digest("sha-256", bytes);
+  const binaryString = bytesToString(new Uint8Array(digest));
+  return base64encodeUrlSafe(binaryString);
 };
+
+/* eslint-enable promise/no-native, no-restricted-globals */

--- a/src/dpop.js
+++ b/src/dpop.js
@@ -1,0 +1,32 @@
+/* @flow */
+
+import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
+
+export const stringToBytes = (string: string): Uint8Array => {
+  // eslint-disable-next-line compat/compat
+  return new TextEncoder().encode(string);
+};
+
+export const bytesToString = (bytes: Uint8Array): string => {
+  return String.fromCharCode(...bytes);
+};
+
+export const base64encodeUrlSafe = (string: string): string => {
+  // https://datatracker.ietf.org/doc/html/rfc7515#appendix-C
+  return btoa(string)
+    .replace(/[=]+/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+};
+
+export const base64decodeUrlSafe = (string: string): string => {
+  return atob(string.replace(/-/g, "+").replace(/_/g, "/"));
+};
+
+export const sha256 = (string: string): ZalgoPromise<string> => {
+  const data = stringToBytes(string);
+  return window.crypto.subtle.digest("sha-256", data).then((digest) => {
+    const binaryString = String.fromCharCode(...new Uint8Array(digest));
+    return ZalgoPromise.resolve(base64encodeUrlSafe(binaryString));
+  });
+};

--- a/src/dpop.js
+++ b/src/dpop.js
@@ -2,8 +2,7 @@
 /* eslint-disable promise/no-native, no-restricted-globals */
 
 export const stringToBytes = (string: string): Uint8Array => {
-  // eslint-disable-next-line compat/compat
-  return new TextEncoder().encode(string);
+  return new Uint8Array([...string].map((c) => c.charCodeAt(0)));
 };
 
 export const bytesToString = (bytes: Uint8Array): string => {

--- a/src/dpop.js
+++ b/src/dpop.js
@@ -24,9 +24,10 @@ export const base64decodeUrlSafe = (string: string): string => {
 };
 
 export const sha256 = (string: string): ZalgoPromise<string> => {
-  const data = stringToBytes(string);
-  return window.crypto.subtle.digest("sha-256", data).then((digest) => {
-    const binaryString = String.fromCharCode(...new Uint8Array(digest));
-    return ZalgoPromise.resolve(base64encodeUrlSafe(binaryString));
+  const bytes = stringToBytes(string);
+  return window.crypto.subtle.digest("sha-256", bytes).then((digest) => {
+    const binaryString = bytesToString(new Uint8Array(digest));
+    const encodedBinaryString = base64encodeUrlSafe(binaryString);
+    return ZalgoPromise.resolve(encodedBinaryString);
   });
 };

--- a/src/dpop.test.js
+++ b/src/dpop.test.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import {
   base64decodeUrlSafe,
@@ -11,7 +11,7 @@ import {
 } from "./dpop";
 
 describe("DPoP", () => {
-  describe("base64", () => {
+  describe("base64 encoding and decoding", () => {
     const decoded = "i·?i·>i·";
     const encoded = "abc_abc-abc";
     it("encoding replaces '/', '+', and '='", () => {

--- a/src/dpop.test.js
+++ b/src/dpop.test.js
@@ -1,0 +1,41 @@
+/* @flow */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  base64decodeUrlSafe,
+  base64encodeUrlSafe,
+  bytesToString,
+  sha256,
+  stringToBytes,
+} from "./dpop";
+
+describe("DPoP", () => {
+  describe("base64", () => {
+    const decoded = "i·?i·>i·";
+    const encoded = "abc_abc-abc";
+    it("encoding replaces '/', '+', and '='", () => {
+      expect(base64encodeUrlSafe(decoded)).toEqual(encoded);
+    });
+    it("decoding adds back the url unsafe characters", () => {
+      expect(base64decodeUrlSafe(encoded)).toEqual(decoded);
+    });
+  });
+  describe("byte array <-> string conversion", () => {
+    it("converts strings to bytes and back again", () => {
+      const string = "abcdefg123456890";
+      expect(bytesToString(stringToBytes(string))).toEqual(string);
+    });
+  });
+  describe("sha256", () => {
+    it("base64 encodes the hash", async () => {
+      // testing a known string and its base64 encoded hash value from:
+      // https://datatracker.ietf.org/doc/html/rfc9449#name-dpop-protected-resource-req
+      const digest = await sha256(
+        "Kz~8mXK1EalYznwH-LC-1fBAo.4Ljp~zsPE_NeO.gxU"
+      );
+      expect(digest).toEqual("fUHyO2r2Z3DZ53EsNrWBb0xWXoaNy59IiKCAqksmQEo");
+      expect.assertions(1);
+    });
+  });
+});

--- a/src/dpop.test.js
+++ b/src/dpop.test.js
@@ -26,6 +26,11 @@ describe("DPoP", () => {
       const string = "abcdefg123456890";
       expect(bytesToString(stringToBytes(string))).toEqual(string);
     });
+    it("converts bytes to binary strings and back again", () => {
+      // >= 128 should not be encoded as utf-8
+      const bytes = new Uint8Array([128]);
+      expect(...stringToBytes(bytesToString(bytes))).toEqual(...bytes);
+    });
   });
   describe("sha256", () => {
     it("base64 encodes the hash", async () => {

--- a/src/dpop.test.js
+++ b/src/dpop.test.js
@@ -15,6 +15,7 @@ describe("DPoP", () => {
     const decoded = "i·?i·>i·";
     const encoded = "abc_abc-abc";
     it("encoding replaces '/', '+', and '='", () => {
+      expect(btoa(decoded)).toEqual("abc/abc+abc=");
       expect(base64encodeUrlSafe(decoded)).toEqual(encoded);
     });
     it("decoding adds back the url unsafe characters", () => {

--- a/test/globals.js
+++ b/test/globals.js
@@ -1,4 +1,5 @@
 /* eslint flowtype/require-valid-file-annotation: off, flowtype/require-return-type: off */
+import crypto from "crypto";
 
 export const sdkClientTestGlobals = {
   __PORT__: 8000,
@@ -20,4 +21,5 @@ export const sdkClientTestGlobals = {
     __EXPERIENCE__: "1122",
     __TREATMENT__: "1234",
   },
+  crypto: crypto.webcrypto,
 };


### PR DESCRIPTION
This PR implements a few utility functions that will be used in an upcoming PR for jwt creation and signatures as part of the larger [DPoP](https://datatracker.ietf.org/doc/html/rfc9449) initiative that will be used in the hosted buttons component. 

I am planning on two follow up prs to this repo:

- one that implements the key pair generation and signing and verification
- one that implements the jwt creation and exports a `dPoPHeaders` function that will be used in checkout-components.