### PR TITLE
add DPoP keygen and thumbprint

### DIFF
--- a/src/dpop.js
+++ b/src/dpop.js
@@ -1,12 +1,12 @@
 /* @flow */
 /* eslint-disable promise/no-native, no-restricted-globals */
 
-type CryptoKey = {|
+type KeyPair = {|
   privateKey: mixed,
   publicKey: mixed,
 |};
 
-type GenerateKeyPair = () => Promise<CryptoKey>;
+type GenerateKeyPair = () => Promise<KeyPair>;
 
 // https://datatracker.ietf.org/doc/html/rfc7518#section-3.1
 const KEY_OPTIONS = {

--- a/src/dpop.js
+++ b/src/dpop.js
@@ -18,9 +18,9 @@ const KEY_OPTIONS = {
   usages: ["sign", "verify"],
 };
 
-let keypair;
+let keyPair;
 export const generateKeyPair: GenerateKeyPair = async () => {
-  if (!keypair) {
+  if (!keyPair) {
     const { create, extractable, usages } = KEY_OPTIONS;
     const { publicKey, privateKey } = await window.crypto.subtle.generateKey(
       create,
@@ -28,10 +28,10 @@ export const generateKeyPair: GenerateKeyPair = async () => {
       usages
     );
 
-    keypair = keypair || { publicKey, privateKey };
+    keyPair = keyPair || { publicKey, privateKey };
   }
 
-  return keypair;
+  return keyPair;
 };
 
 export const stringToBytes = (string: string): Uint8Array => {

--- a/src/dpop.js
+++ b/src/dpop.js
@@ -2,8 +2,8 @@
 /* eslint-disable promise/no-native, no-restricted-globals */
 
 type CryptoKey = {|
-  publicKey: mixed,
   privateKey: mixed,
+  publicKey: mixed,
 |};
 
 type GenerateKeyPair = () => Promise<CryptoKey>;

--- a/src/dpop.js
+++ b/src/dpop.js
@@ -1,6 +1,39 @@
 /* @flow */
 /* eslint-disable promise/no-native, no-restricted-globals */
 
+type CryptoKey = {|
+  publicKey: mixed,
+  privateKey: mixed,
+|};
+
+type GenerateKeyPair = () => Promise<CryptoKey>;
+
+// https://datatracker.ietf.org/doc/html/rfc7518#section-3.1
+const KEY_OPTIONS = {
+  create: {
+    name: "ECDSA",
+    namedCurve: "P-256",
+  },
+  extractable: false,
+  usages: ["sign", "verify"],
+};
+
+let keypair;
+export const generateKeyPair: GenerateKeyPair = async () => {
+  if (!keypair) {
+    const { create, extractable, usages } = KEY_OPTIONS;
+    const { publicKey, privateKey } = await window.crypto.subtle.generateKey(
+      create,
+      extractable,
+      usages
+    );
+
+    keypair = keypair || { publicKey, privateKey };
+  }
+
+  return keypair;
+};
+
 export const stringToBytes = (string: string): Uint8Array => {
   return new Uint8Array([...string].map((c) => c.charCodeAt(0)));
 };
@@ -26,6 +59,12 @@ export const sha256 = async (string: string): Promise<string> => {
   const digest = await window.crypto.subtle.digest("sha-256", bytes);
   const binaryString = bytesToString(new Uint8Array(digest));
   return base64encodeUrlSafe(binaryString);
+};
+
+export const jsonWebKeyThumbprint = async (jwk: Object): Promise<string> => {
+  // https://datatracker.ietf.org/doc/html/rfc7638#section-3.2
+  const { crv, e, kty, n, x, y } = jwk;
+  return await sha256(JSON.stringify({ crv, e, kty, n, x, y }));
 };
 
 /* eslint-enable promise/no-native, no-restricted-globals */

--- a/src/dpop.test.js
+++ b/src/dpop.test.js
@@ -6,6 +6,8 @@ import {
   base64decodeUrlSafe,
   base64encodeUrlSafe,
   bytesToString,
+  generateKeyPair,
+  jsonWebKeyThumbprint,
   sha256,
   stringToBytes,
 } from "./dpop";
@@ -42,6 +44,32 @@ describe("DPoP", () => {
       );
       expect(digest).toEqual("fUHyO2r2Z3DZ53EsNrWBb0xWXoaNy59IiKCAqksmQEo");
       expect.assertions(1);
+    });
+  });
+  describe("keypair generation", () => {
+    it("memoizes the keypair", async () => {
+      const { publicKey: publicKey1 } = await generateKeyPair();
+      const jwk1 = await window.crypto.subtle.exportKey("jwk", publicKey1);
+      const { publicKey: publicKey2 } = await generateKeyPair();
+      const jwk2 = await window.crypto.subtle.exportKey("jwk", publicKey2);
+      expect(jwk1.x).toBeTruthy();
+      expect(jwk1).toStrictEqual(jwk2);
+    });
+  });
+  describe("JSON Web Key Thumbprint", () => {
+    it("generates a correct thumbprint", async () => {
+      // testing a known JSON Web Key and its thumbprint from:
+      // https://datatracker.ietf.org/doc/html/rfc7638#section-3.1
+      const key = {
+        kty: "RSA",
+        n: "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+        e: "AQAB",
+        alg: "RS256",
+        kid: "2011-04-29",
+      };
+      expect(await jsonWebKeyThumbprint(key)).toBe(
+        "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs"
+      );
     });
   });
 });

--- a/src/dpop.test.js
+++ b/src/dpop.test.js
@@ -46,8 +46,8 @@ describe("DPoP", () => {
       expect.assertions(1);
     });
   });
-  describe("keypair generation", () => {
-    it("memoizes the keypair", async () => {
+  describe("key pair generation", () => {
+    it("memoizes the key pair", async () => {
       const { publicKey: publicKey1 } = await generateKeyPair();
       const jwk1 = await window.crypto.subtle.exportKey("jwk", publicKey1);
       const { publicKey: publicKey2 } = await generateKeyPair();


### PR DESCRIPTION
This PR is a follow-up to https://github.com/paypal/paypal-sdk-client/pull/184 and implements key pair generation and a `jsonWebKeyThumbprint` function that serializes and hashes a JSON web key.

The next (last) PR will implement the JWT creation and signature.