### PR TITLE
add DPoP createJWT and buildDPoPHeaders function

### DIFF
--- a/src/dpop.js
+++ b/src/dpop.js
@@ -61,7 +61,9 @@ export const generateKeyPair: GenerateKeyPair = async () => {
 };
 
 export const stringToBytes = (string: string): Uint8Array => {
-  return new Uint8Array([...string].map((c) => c.charCodeAt(0)));
+  // webpack transforms [..."string"] to [].concat("string")
+  // eslint-disable-next-line unicorn/prefer-spread
+  return new Uint8Array(string.split("").map((c) => c.charCodeAt(0)));
 };
 
 export const bytesToString = (bytes: Uint8Array): string => {

--- a/src/index.js
+++ b/src/index.js
@@ -17,3 +17,4 @@ export * from "./graphql";
 export * from "./domains";
 export * from "./tracking";
 export * from "./utils";
+export { buildDPoPHeaders } from "./dpop";


### PR DESCRIPTION
This PR is a follow-up PR to https://github.com/paypal/paypal-sdk-client/pull/186 and is the last of the DPoP related changes in sdk-client.

This PR implements the JWT creation and signature and exports a single method to consumers of this package, `buildDPoPHeaders`, that abstracts away all of the lower-level cryptographic and encoding related functionality. 