### PR TITLE
Fix node 18 type error

### DIFF
--- a/src/dpop.test.js
+++ b/src/dpop.test.js
@@ -121,7 +121,7 @@ describe("DPoP", () => {
         },
         publicKey,
         signature,
-        `${encodedHeader}.${encodedPayload}`
+        stringToBytes(`${encodedHeader}.${encodedPayload}`)
       );
       expect(verified).toBe(true);
     });


### PR DESCRIPTION
This PR fixes an issue where `crypto.subtle.verify` expects a byte array for the signature instead of a string. see https://github.com/paypal/paypal-sdk-client/actions/runs/8009694187/job/21878949911#step:7:204

After this PR is merged, I would like to submit another PR to update the node version in main.yml:
https://github.com/paypal/paypal-sdk-client/blob/639b4d5312db22dc4127cb25b41b8ebae73e8b5b/.github/workflows/main.yml#L17-L19

because it differs from the publish action's node version: 

https://github.com/paypal/paypal-sdk-client/blob/639b4d5312db22dc4127cb25b41b8ebae73e8b5b/.nvmrc#L1

https://github.com/paypal/paypal-sdk-client/blob/639b4d5312db22dc4127cb25b41b8ebae73e8b5b/.github/workflows/publish.yml#L11-L18