### PR TITLE
use node version from .nvmrc in ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,15 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
 
+      - name: 🤝 Set Node version from .nvmrc
+        run: echo NVMRC=`cat .nvmrc` >> $GITHUB_ENV
+
       - name: ⎔ Setup node
+        # sets up the .npmrc file to publish to npm
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: ${{ env.NVMRC }}
+          registry-url: "https://registry.npmjs.org"
 
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1


### PR DESCRIPTION
This PR fixes an issue where pull requests are tested using node 16 but npm publish actions are tested using node 18.

I copied over the yaml from `publish.yml`:
https://github.com/paypal/paypal-sdk-client/blob/4b87e823d890abbc7187dfa0800277e237427a59/.github/workflows/publish.yml#L14-L18