### PR TITLE
Fix for incorrect metric causing high cardinality

### DIFF
--- a/src/tracking.js
+++ b/src/tracking.js
@@ -171,26 +171,11 @@ export function setupLogger() {
     );
 
     if (loadTime) {
-      logger
-        // We can not send gauge metrics to our logger backend currently
-        // once we have that ability, we should uncomment this gauge metric
-        // .metricGauge({
-        //   namespace: "sdk_client.init.gauge",
-        //   event: "load_performance",
-        //   value: sdkLoadTime,
-        //   dimensions: {
-        //     cacheType,
-        //     version,
-        //     components: getComponents().join(","),
-        //     isPayPalDomain: isLoadedInFrame,
-        //     token: getTokenType(),
-        //   },
-        // })
-        .track({
-          [FPTI_KEY.TRANSITION]: "process_js_sdk_init_client",
-          [FPTI_KEY.SDK_LOAD_TIME]: sdkLoadTime,
-          [FPTI_KEY.SDK_CACHE]: cacheType,
-        });
+      logger.track({
+        [FPTI_KEY.TRANSITION]: "process_js_sdk_init_client",
+        [FPTI_KEY.SDK_LOAD_TIME]: sdkLoadTime,
+        [FPTI_KEY.SDK_CACHE]: cacheType,
+      });
     }
 
     if (isIEIntranet()) {
@@ -203,7 +188,7 @@ export function setupLogger() {
       dimensions: {
         components: getComponents().join(","),
         integrationSource,
-        isPayPalDomain: isLoadedInFrame,
+        isPayPalDomain: Boolean(isLoadedInFrame).toString(),
         jsSdkLibrary,
         pageType,
         token: getTokenType(),

--- a/src/tracking.test.js
+++ b/src/tracking.test.js
@@ -1,4 +1,5 @@
 /* @flow */
+/* eslint-disable promise/no-native, no-restricted-globals, compat/compat */
 import { describe, it, vi, expect } from "vitest";
 
 import { makeMockScriptElement } from "../test/helpers";
@@ -8,12 +9,33 @@ import { getSDKInitTime, setupLogger } from "./tracking";
 const clientId = "foobar123";
 const mockScriptSrc = `https://test.paypal.com/sdk/js?client-id=${clientId}`;
 
+let metricCounterSpy;
+let windowReadyPromiseResolver;
+vi.mock("./logger", async () => {
+  const actual = await vi.importActual("./logger");
+  return {
+    ...actual,
+    getLogger: vi.fn(() => {
+      const logger = actual.getLogger();
+      metricCounterSpy = vi
+        .spyOn(logger, "metricCounter")
+        .mockImplementation(() => {}); // eslint-disable-line no-empty-function
+      return logger;
+    }),
+  };
+});
 vi.mock("@krakenjs/belter/src", async () => {
   const actual = await vi.importActual("@krakenjs/belter/src");
+
   return {
     ...actual,
     getCurrentScript: vi.fn(() => {
       return makeMockScriptElement(mockScriptSrc);
+    }),
+    waitForWindowReady: vi.fn(() => {
+      return new Promise((resolve) => {
+        windowReadyPromiseResolver = resolve;
+      });
     }),
   };
 });
@@ -33,4 +55,20 @@ describe(`tracking cases`, () => {
     window.document.documentMode = true;
     setupLogger();
   });
+
+  it("should call metric counter on window load", async () => {
+    windowReadyPromiseResolver();
+    await new Promise((resolve) => setTimeout(resolve)); // Flush promises
+
+    expect(metricCounterSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        namespace: "sdk_client.init.count",
+        dimensions: expect.objectContaining({
+          isPayPalDomain: "false",
+        }),
+      })
+    );
+  });
 });
+
+/* eslint-enable promise/no-native, no-restricted-globals, compat/compat */


### PR DESCRIPTION
The `isLoadedInFrame` variable previously was `isPayPalDomain() && window.xprops`. Because of the && operator, the value here would be the value of window.xprops which is a very high cardinality value. We ended up having metrics disabled due to the cardinality of these events so casting to a Boolean should solve for that.

One thing I'm not clear on is why we're mapping `isLoadedInFrame` to `isPayPalDomain` and not calling `isPayPalDomain()` directly, but I'm only trying to solve the cardinality issue on this event.