### PR TITLE
Hardcode library values

### DIFF
--- a/src/script.test.js
+++ b/src/script.test.js
@@ -6,6 +6,7 @@ import { SDK_SETTINGS } from "@paypal/sdk-constants/src";
 
 import { makeMockScriptElement } from "../test/helpers";
 
+import { getJsLibrary } from "./tracking";
 import {
   getClientID,
   getIntent,
@@ -17,7 +18,6 @@ import {
   getMerchantID,
   getClientAccessToken,
   getSDKIntegrationSource,
-  getJsSdkLibrary,
   getPageType,
   getLocale,
   getMerchantRequestedPopupsDisabled,
@@ -255,6 +255,14 @@ describe(`script cases`, () => {
     expect(getSDKIntegrationSource()).toEqual(SDKIntegrationSource);
   });
 
+  it("should return none when there is no js sdk library", () => {
+    const mockElement = makeMockScriptElement(mockScriptSrc);
+    // $FlowIgnore
+    getCurrentScript.mockReturnValue(mockElement);
+
+    expect(getJsLibrary()).toEqual("none");
+  });
+
   it("should successfully get js sdk library", () => {
     const jsSdkLibrary = "react-paypal-js";
     const mockElement = makeMockScriptElement(mockScriptSrc);
@@ -262,7 +270,7 @@ describe(`script cases`, () => {
     // $FlowIgnore
     getCurrentScript.mockReturnValue(mockElement);
 
-    expect(getJsSdkLibrary()).toEqual(jsSdkLibrary);
+    expect(getJsLibrary()).toEqual(jsSdkLibrary);
   });
 
   it("should successfully get popup disabled attribute as true when set to true", () => {

--- a/src/script.test.js
+++ b/src/script.test.js
@@ -2,7 +2,7 @@
 /* eslint max-lines: off */
 import { describe, it, afterEach, beforeEach, expect, vi } from "vitest";
 import { base64encode, getCurrentScript, memoize } from "@krakenjs/belter/src";
-import { JS_SDK_LIBRARIES, SDK_SETTINGS } from "@paypal/sdk-constants/src";
+import { SDK_SETTINGS } from "@paypal/sdk-constants/src";
 
 import { makeMockScriptElement } from "../test/helpers";
 
@@ -256,7 +256,7 @@ describe(`script cases`, () => {
   });
 
   it("should successfully get js sdk library", () => {
-    const jsSdkLibrary = JS_SDK_LIBRARIES.REACT_PAYPAL_JS;
+    const jsSdkLibrary = "react-paypal-js";
     const mockElement = makeMockScriptElement(mockScriptSrc);
     mockElement.setAttribute(SDK_SETTINGS.JS_SDK_LIBRARY, jsSdkLibrary);
     // $FlowIgnore

--- a/src/tracking.js
+++ b/src/tracking.js
@@ -66,6 +66,16 @@ const getIntegrationSource = (): string => {
   }
 };
 
+export const getJsLibrary = (): string => {
+  const jsSdkLibrary = getJsSdkLibrary();
+
+  if (jsSdkLibrary) {
+    return jsSdkLibrary;
+  } else {
+    return "none";
+  }
+};
+
 const getPageType = (): string => {
   const pageType = getSDKPageType();
 
@@ -88,7 +98,7 @@ export function setupLogger() {
   const logger = getLogger();
   const pageType = getPageType();
   const integrationSource = getIntegrationSource();
-  const jsSdkLibrary = getJsSdkLibrary();
+  const jsSdkLibrary = getJsLibrary();
   const version = getVersion();
   const userAction = getCommit()
     ? FPTI_USER_ACTION.COMMIT


### PR DESCRIPTION
### Description

@gregjopa, @westeezy, and I had a solid chat about DTPPCPSDK-1482 where it was decided we'd remove `JS_SDK_LIBRARIES` from `@paypal/sdk-constants` and hardcode values. This was inspired by the difficulty of adding `@paypal/sdk-constants` as a dependency of `paypal-js`. Additionally, it was decided that `"none"` was a better value than `"raw-script"` for when a library isn't being used to load the JS SDK.