### PR TITLE
Add initial entry point for vault flows with SDK token

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "flow-typed": "^3.8.0",
     "husky": "^8.0.1",
     "jsdom": "^20.0.3",
+    "jsonwebtoken": "^9.0.2",
     "lint-staged": "^13.0.3",
     "prettier": "2.8.8",
     "@vitest/coverage-v8": "^1.0.0",

--- a/src/script.js
+++ b/src/script.js
@@ -235,10 +235,6 @@ export function getAmount(): ?string {
   return amount;
 }
 
-export function getUserIDToken(): ?string {
-  return getSDKAttribute(SDK_SETTINGS.USER_ID_TOKEN);
-}
-
 export function getClientAccessToken(): ?string {
   const clientToken = getClientToken();
 
@@ -330,8 +326,41 @@ export function getUserExperienceFlow(): ?string {
   return getSDKAttribute(SDK_SETTINGS.USER_EXPERIENCE_FLOW);
 }
 
+export function getUserIDToken(): ?string {
+  if (
+    getSDKAttribute(SDK_SETTINGS.SDK_TOKEN) &&
+    !getSDKAttribute(SDK_SETTINGS.USER_ID_TOKEN)
+  ) {
+    return getSDKAttribute(SDK_SETTINGS.SDK_TOKEN);
+  }
+
+  return getSDKAttribute(SDK_SETTINGS.USER_ID_TOKEN);
+}
+
 export function getSDKToken(): ?string {
+  if (
+    getSDKAttribute(SDK_SETTINGS.SDK_TOKEN) &&
+    getSDKAttribute(SDK_SETTINGS.USER_ID_TOKEN)
+  ) {
+    throw new Error("Do not pass SDK token and ID token");
+  }
+
   return getSDKAttribute(SDK_SETTINGS.SDK_TOKEN);
+}
+
+export function getCustomerId(): string {
+  const sdkToken = getSDKAttribute(SDK_SETTINGS.SDK_TOKEN);
+
+  if (sdkToken && typeof atob === "function") {
+    try {
+      const { options = {} } = JSON.parse(window.atob(sdkToken.split(".")[1]));
+      return options.customer_id || "";
+    } catch {
+      throw new Error("Error decoding SDK token");
+    }
+  }
+
+  return "";
 }
 
 /* v8 ignore next 3 */

--- a/src/script.js
+++ b/src/script.js
@@ -348,19 +348,23 @@ export function getSDKToken(): ?string {
   return getSDKAttribute(SDK_SETTINGS.SDK_TOKEN);
 }
 
-export function getCustomerId(): string {
-  const sdkToken = getSDKAttribute(SDK_SETTINGS.SDK_TOKEN);
-
-  if (sdkToken && typeof atob === "function") {
-    try {
-      const { options = {} } = JSON.parse(window.atob(sdkToken.split(".")[1]));
+type decodedCustomerId = (string) => string;
+export const decodeCustomerIdFromToken: decodedCustomerId = memoize((token) => {
+  try {
+    if (token && typeof atob === "function") {
+      const { options = {} } = JSON.parse(window.atob(token.split(".")[1]));
       return options.customer_id || "";
-    } catch {
-      throw new Error("Error decoding SDK token");
     }
-  }
 
-  return "";
+    return "";
+  } catch {
+    throw new Error("Error decoding SDK token");
+  }
+});
+
+export function getCustomerId(): string {
+  const sdkToken = getSDKAttribute(SDK_SETTINGS.SDK_TOKEN) || "";
+  return decodeCustomerIdFromToken(sdkToken);
 }
 
 /* v8 ignore next 3 */

--- a/src/script.test.js
+++ b/src/script.test.js
@@ -28,6 +28,8 @@ import {
   getBuyerCountry,
   getAmount,
   getUserIDToken,
+  getSDKToken,
+  getCustomerId,
   getCSPNonce,
   getEnableThreeDomainSecure,
   getUserExperienceFlow,
@@ -535,7 +537,7 @@ describe(`script cases`, () => {
     });
   });
 
-  it("getUserIDToken return a token string", () => {
+  it("getUserIDToken returns a token string", () => {
     const inputToken = "some-token";
     const mockElement = makeMockScriptElement(mockScriptSrc);
     mockElement.setAttribute("data-user-id-token", inputToken);
@@ -544,6 +546,52 @@ describe(`script cases`, () => {
 
     const result = getUserIDToken();
     expect(result).toEqual(inputToken);
+  });
+
+  it("getUserIDToken is set as SDK token if SDK token is passed only", () => {
+    const sdkToken = "some-token";
+    const mockElement = makeMockScriptElement(mockScriptSrc);
+    mockElement.setAttribute("data-sdk-client-token", sdkToken);
+    // $FlowIgnore
+    getCurrentScript.mockReturnValue(mockElement);
+
+    const result = getUserIDToken();
+    expect(result).toEqual(sdkToken);
+  });
+
+  it("getSDKToken returns a token string", () => {
+    const inputToken = "some-token";
+    const mockElement = makeMockScriptElement(mockScriptSrc);
+    mockElement.setAttribute("data-sdk-client-token", inputToken);
+    // $FlowIgnore
+    getCurrentScript.mockReturnValue(mockElement);
+
+    const result = getSDKToken();
+    expect(result).toEqual(inputToken);
+  });
+
+  it("getSDKToken errors if ID token is also passed", () => {
+    const inputToken = "some-token";
+    const mockElement = makeMockScriptElement(mockScriptSrc);
+    mockElement.setAttribute("data-sdk-client-token", inputToken);
+    mockElement.setAttribute("data-user-id-token", inputToken);
+    // $FlowIgnore
+    getCurrentScript.mockReturnValue(mockElement);
+
+    expect(getSDKToken).toThrow("Do not pass SDK token and ID token");
+  });
+
+  it("getCustomerId returns a string of the decoded customer_id from the SDK token", () => {
+    const encodedPayload =
+      ".eyJvcHRpb25zIjp7ImN1c3RvbWVyX2lkIjoidGVzdDEyMyJ9fQ==";
+    const encodedCustomerId = "test123";
+    const mockElement = makeMockScriptElement(mockScriptSrc);
+    mockElement.setAttribute("data-sdk-client-token", encodedPayload);
+    // $FlowIgnore
+    getCurrentScript.mockReturnValue(mockElement);
+
+    const result = getCustomerId();
+    expect(result).toEqual(encodedCustomerId);
   });
 
   it("getCSPNonce should return a data-csp-nonce string", () => {


### PR DESCRIPTION
This PR is an initial entrance to allow the latest vault flow (ID token) to work the new SDK token. It will not enable the e2e flow just yet.

When SDK token is passed alone, internally we will set the ID token as the SDK token value. We also will use this new getCustomerId function that decodes the SDK token for UX improvements to prevent an API call/correct loading state.