### PR TITLE
Updated the @paypal/sdk-constants dependency version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@krakenjs/cross-domain-utils": "^3.0.2",
     "@krakenjs/jsx-pragmatic": "^3.0.0",
     "@krakenjs/zalgo-promise": "^2.0.0",
-    "@paypal/sdk-constants": "^1.0.143",
+    "@paypal/sdk-constants": "^1.0.148",
     "bowser": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This should have been part of https://github.com/paypal/paypal-sdk-client/pull/196, since this now relies on the new constant added in https://github.com/paypal/paypal-sdk-constants/pull/149.