### PR TITLE
fix invalid venmo domain tests

### DIFF
--- a/src/domains.test.js
+++ b/src/domains.test.js
@@ -65,9 +65,16 @@ describe(`domains test`, () => {
 
   it("should not match invalid venmo domains", () => {
     const invalidDomains = [
-      "www.venmo.com.example.com",
-      "www.venmo.cn.example.com",
-      "www.venmo.com",
+      "https://www.venmo.com.example.com",
+      "https://www.venmo.cn.example.com",
+      "http://www.venmo.com.example.com",
+      "http://www.venmo.cn.example.com",
+      "http://www.example.com",
+      "https://www.example.com",
+      "https://venmo.com.example.com",
+      "https://venmo.cn.example.com",
+      "http://venmo.com.example.com",
+      "http://venmo.cn.example.com",
     ];
 
     for (const domain of invalidDomains) {


### PR DESCRIPTION
The test case written to validate invalid Venmo domains are currently asserting for invalid domain by not passing protocol (http/https) in the input values.
This results in `www.venmo.com` being validated as invalid Venmo domain, and `https://www.venmo.com` being valid domain. 

A crucial part of invalid domain validation must be to also validate the eTLD+1 of the Venmo domain. 

This PR fixes by adding the protocol to the input values.