### PR TITLE
Add wasShopperInsightsUsed 👾

### DIFF
--- a/src/session.js
+++ b/src/session.js
@@ -36,7 +36,7 @@ export function wasShopperInsightsUsed(): boolean {
   let shopperInsightsUsed = false;
 
   getSessionState((state) => {
-    const shopperInsightsState = state["shopperInsights"];
+    const shopperInsightsState = state.shopperInsights;
 
     // Set shopperInsightsUsed to true if it finds either one of these values in the state
     shopperInsightsUsed = Boolean(

--- a/src/session.js
+++ b/src/session.js
@@ -31,3 +31,19 @@ export function getStorageID(): string {
 export function getSessionState<T>(handler: (state: Object) => T): T {
   return getSDKStorage().getSessionState(handler);
 }
+
+export function wasShopperInsightsUsed(): boolean {
+  let shopperInsightsUsed = false;
+
+  getSessionState((state) => {
+    const shopperInsightsState = state["shopperInsights"];
+
+    // Set shopperInsightsUsed to true if it finds either one of these values in the state
+    shopperInsightsUsed = Boolean(
+      shopperInsightsState?.shopperInsightsIsMemberUsed ||
+        shopperInsightsState?.getRecommendedPaymentMethodsUsed
+    );
+  });
+
+  return shopperInsightsUsed;
+}

--- a/src/session.test.js
+++ b/src/session.test.js
@@ -77,7 +77,58 @@ describe("session cases", () => {
     });
   });
 
-  it("wasShopperInsightsUsed should return false if shopperInsights doesn't exist in the state", () => {
-    expect(wasShopperInsightsUsed()).toEqual(false);
+  describe.only("wasShopperInsightsUsed", () => {
+    let mockState;
+
+    const mockGetSessionState = (handler: (state: Object) => void) => {
+      handler(mockState);
+    };
+
+    it("should return false if shopperInsights doesn't exist in the state", () => {
+      expect(wasShopperInsightsUsed()).toEqual(false);
+    });
+
+    it("should return false if shopperInsightsState exists but does not include shopperInsightsIsMemberUsed or getRecommendedPaymentMethodsUsed", () => {
+      mockState = {
+        shopperInsights: {},
+      };
+
+      // $FlowIssue
+      getStorage.mockImplementationOnce(() => ({
+        getSessionState: mockGetSessionState,
+      }));
+
+      expect(wasShopperInsightsUsed()).toEqual(false);
+    });
+
+    it("should return true if shopperInsightsState includes shopperInsightsIsMemberUsed", () => {
+      mockState = {
+        shopperInsights: {
+          shopperInsightsIsMemberUsed: true,
+        },
+      };
+
+      // $FlowIssue
+      getStorage.mockImplementationOnce(() => ({
+        getSessionState: mockGetSessionState,
+      }));
+
+      expect(wasShopperInsightsUsed()).toEqual(true);
+    });
+
+    it("should return true if shopperInsightsState includes getRecommendedPaymentMethodsUsed", () => {
+      mockState = {
+        shopperInsights: {
+          getRecommendedPaymentMethodsUsed: true,
+        },
+      };
+
+      // $FlowIssue
+      getStorage.mockImplementationOnce(() => ({
+        getSessionState: mockGetSessionState,
+      }));
+
+      expect(wasShopperInsightsUsed()).toEqual(true);
+    });
   });
 });

--- a/src/session.test.js
+++ b/src/session.test.js
@@ -1,5 +1,5 @@
 /* @flow */
-import { describe, it, afterEach, expect, vi, beforeAll } from "vitest";
+import { describe, it, afterEach, expect, vi } from "vitest";
 import { getCurrentScript, memoize, getStorage } from "@krakenjs/belter/src";
 
 import { makeMockScriptElement } from "../test/helpers";

--- a/src/session.test.js
+++ b/src/session.test.js
@@ -77,7 +77,7 @@ describe("session cases", () => {
     });
   });
 
-  describe.only("wasShopperInsightsUsed", () => {
+  describe("wasShopperInsightsUsed", () => {
     let mockState;
 
     const mockGetSessionState = (handler: (state: Object) => void) => {

--- a/src/session.test.js
+++ b/src/session.test.js
@@ -1,5 +1,5 @@
 /* @flow */
-import { describe, it, afterEach, expect, vi } from "vitest";
+import { describe, it, afterEach, expect, vi, beforeAll } from "vitest";
 import { getCurrentScript, memoize, getStorage } from "@krakenjs/belter/src";
 
 import { makeMockScriptElement } from "../test/helpers";
@@ -10,6 +10,7 @@ import {
   getSessionState,
   getClientMetadataID,
   getSDKStorage,
+  wasShopperInsightsUsed,
 } from "./session";
 
 const clientId = "foobar123";
@@ -74,5 +75,9 @@ describe("session cases", () => {
       name: expect.any(String),
       stickySessionId: expect.any(String),
     });
+  });
+
+  it("wasShopperInsightsUsed should return false if shopperInsights doesn't exist in the state", () => {
+    expect(wasShopperInsightsUsed()).toEqual(false);
   });
 });


### PR DESCRIPTION
**JIRA:** [DTPPCPSDK-2369](https://paypal.atlassian.net/browse/DTPPCPSDK-2369)

- _**💥 Adds wasShopperInsightsUsed function**_ - Checks session state for key indicators that shopper insights was used