### PR TITLE
Update getFirstRenderExperiments types

### DIFF
--- a/src/global.js
+++ b/src/global.js
@@ -140,9 +140,10 @@ export function getExperimentation(): Experimentation | null {
   return null;
 }
 
-export function getFirstRenderExperiments(): FirstRenderExperiments | null {
+export function getFirstRenderExperiments(): FirstRenderExperiments | Object {
   if (typeof __FIRST_RENDER_EXPERIMENTS__ !== "undefined") {
     return __FIRST_RENDER_EXPERIMENTS__;
   }
+
   return {};
 }

--- a/src/types.js
+++ b/src/types.js
@@ -24,6 +24,6 @@ export type GetExperimentation = {
   [any]: empty,
 };
 
-export type FirstRenderExperiments = {
-  [key: string]: boolean,
-};
+export type FirstRenderExperiments = {|
+  venmoVaultWithoutPurchase?: boolean,
+|};


### PR DESCRIPTION
Flow was complaining about the typing of the inexactness of getFirstRenderExperiments so I made it more exact.