### PR TITLE
chore: allow extra parameters to pass through to the bridge url

### DIFF
--- a/server/meta.integration.test.js
+++ b/server/meta.integration.test.js
@@ -118,6 +118,17 @@ const sdkMetaList = [
       },
     },
   ],
+  [
+    {
+      url: "https://www.paypal.com/web-sdk/v6/bridge?",
+      origin: "https://www.whiterabbitvintagemarket.com",
+      version: "6.4.1",
+      "payment-flow": "popup",
+      debug: "false",
+    },
+    // no attributes
+    {},
+  ],
 ];
 
 // $FlowIgnore[prop-missing] missing each property for test

--- a/server/meta.jsx
+++ b/server/meta.jsx
@@ -90,58 +90,44 @@ function validateWebSDKUrl({ pathname, query }) {
       `Invalid path for web-sdk bridge url: ${pathname || "undefined"}`
     );
   }
-  // check for extraneous parameters
-  const validWebSDKBridgeParams = [
-    "origin",
-    "version",
-    "payment-flow",
-    "debug",
-  ];
-  for (const param of Object.keys(query)) {
-    if (!validWebSDKBridgeParams.includes(param)) {
-      throw new Error(`Invalid parameter on web-sdk bridge url: ${param}`);
-    }
-  }
+
+  // supported query string parameters
+  const { origin, version, ["payment-flow"]: paymentflow, debug } = query;
 
   // validate the version parameter
-  if (query.version === undefined || !semverRegex.test(query.version)) {
+  if (version === undefined || !semverRegex.test(version)) {
     throw new Error(
-      `Invalid version parameter on web-sdk bridge url: ${query.version}`
+      `Invalid version parameter on web-sdk bridge url: ${version}`
     );
   }
 
   // validate the payment-flow parameter
   const validPaymentFlows = ["popup", "modal", "payment-handler"];
-  if (
-    query["payment-flow"] === undefined ||
-    !validPaymentFlows.includes(query["payment-flow"])
-  ) {
+  if (paymentflow === undefined || !validPaymentFlows.includes(paymentflow)) {
     throw new Error(
-      `Invalid payment-flow parameter on web-sdk bridge url: ${query["payment-flow"]}`
+      `Invalid payment-flow parameter on web-sdk bridge url: ${paymentflow}`
     );
   }
 
   // validate the optional debug parameter
-  if (query.debug && !["true", "false"].includes(query.debug)) {
-    throw new Error(
-      `Invalid debug parameter on web-sdk bridge url: ${query["debug"]}`
-    );
+  if (debug && !["true", "false"].includes(debug)) {
+    throw new Error(`Invalid debug parameter on web-sdk bridge url: ${debug}`);
   }
 
   // validate the origin parameter
   let url = null;
   try {
     // eslint-disable-next-line compat/compat
-    url = new URL(query.origin);
+    url = new URL(origin);
   } catch (error) {
     throw new Error(
-      `Invalid origin parameter on web-sdk bridge url: ${query.origin}`
+      `Invalid origin parameter on web-sdk bridge url: ${origin}`
     );
   }
   // check that the origin URL only includes the origin
-  if (query.origin !== `${url.protocol}//${url.host}`) {
+  if (origin !== `${url.protocol}//${url.host}`) {
     throw new Error(
-      `Invalid origin parameter on web-sdk bridge url: ${query.origin}`
+      `Invalid origin parameter on web-sdk bridge url: ${origin}`
     );
   }
 }

--- a/server/meta.test.js
+++ b/server/meta.test.js
@@ -1251,28 +1251,33 @@ test("should construct a valid web-sdk bridge url", () => {
   }
 });
 
-test("should error when extra parameters are present", () => {
+test("should allow extra parameters to be present", () => {
   const sdkUrl =
     "https://www.paypal.com/web-sdk/v6/bridge?version=1.2.3&origin=https%3A%2F%2Fwww.example.com%3A8000&payment-flow=payment-handler&name=value";
 
-  let error = null;
-  try {
-    unpackSDKMeta(
-      Buffer.from(
-        JSON.stringify({
-          url: sdkUrl,
-          attrs: {
-            "data-uid": "abc123",
-          },
-        })
-      ).toString("base64")
-    );
-  } catch (err) {
-    error = err;
-  }
+  const sdkUID = "abc123";
 
-  if (!error) {
-    throw new Error("Expected error to be thrown");
+  const { getSDKLoader } = unpackSDKMeta(
+    Buffer.from(
+      JSON.stringify({
+        url: sdkUrl,
+        attrs: {
+          "data-uid": sdkUID,
+        },
+      })
+    ).toString("base64")
+  );
+
+  const $ = cheerio.load(getSDKLoader());
+  const script = $("script");
+  const src = script.attr("src");
+  const uid = script.attr("data-uid");
+
+  if (src !== sdkUrl) {
+    throw new Error(`Expected script url to be ${sdkUrl} - got ${src}`);
+  }
+  if (uid !== sdkUID) {
+    throw new Error(`Expected data UID be ${sdkUID} - got ${uid}`);
   }
 });
 

--- a/server/meta.test.js
+++ b/server/meta.test.js
@@ -1273,6 +1273,8 @@ test("should allow extra parameters to be present", () => {
   const src = script.attr("src");
   const uid = script.attr("data-uid");
 
+  console.log(sdkUrl);
+
   if (src !== sdkUrl) {
     throw new Error(`Expected script url to be ${sdkUrl} - got ${src}`);
   }


### PR DESCRIPTION
This PR updates the web sdk bridge logic to allow for extra parameters to be passed through. These extra parameters will be validated and accepted/rejected at a different step outside this codebase. The purpose of this change is to make updating sdk-client easier in the future for the web sdk.