### PR TITLE
Update 'payment-flow' param for web-sdk bridge to be optional

### DIFF
--- a/server/meta.integration.test.js
+++ b/server/meta.integration.test.js
@@ -118,6 +118,17 @@ const sdkMetaList = [
       },
     },
   ],
+  [
+    {
+      url: "https://www.paypal.com/web-sdk/v6/bridge?",
+      origin: "https://www.whiterabbitvintagemarket.com",
+      version: "6.4.1",
+      "payment-flow": "popup",
+      debug: "false",
+    },
+    // no attributes
+    {},
+  ],
 ];
 
 // $FlowIgnore[prop-missing] missing each property for test

--- a/server/meta.jsx
+++ b/server/meta.jsx
@@ -110,10 +110,10 @@ function validateWebSDKUrl({ pathname, query }) {
     );
   }
 
-  // validate the payment-flow parameter
+  // validate the optional payment-flow parameter
   const validPaymentFlows = ["popup", "modal", "payment-handler"];
   if (
-    query["payment-flow"] === undefined ||
+    query["payment-flow"] &&
     !validPaymentFlows.includes(query["payment-flow"])
   ) {
     throw new Error(

--- a/server/meta.test.js
+++ b/server/meta.test.js
@@ -1305,6 +1305,35 @@ test("should not error when the optional debug parameter is missing", () => {
   }
 });
 
+test("should not error when the optional payment-flow parameter is missing", () => {
+  const sdkUrl =
+    "https://www.paypal.com/web-sdk/v6/bridge?version=1.2.3&origin=https%3A%2F%2Fwww.example.com%3A8000&debug=false";
+  const sdkUID = "abc123";
+
+  const { getSDKLoader } = unpackSDKMeta(
+    Buffer.from(
+      JSON.stringify({
+        url: sdkUrl,
+        attrs: {
+          "data-uid": sdkUID,
+        },
+      })
+    ).toString("base64")
+  );
+
+  const $ = cheerio.load(getSDKLoader());
+  const script = $("script");
+  const src = script.attr("src");
+  const uid = script.attr("data-uid");
+
+  if (src !== sdkUrl) {
+    throw new Error(`Expected script url to be ${sdkUrl} - got ${src}`);
+  }
+  if (uid !== sdkUID) {
+    throw new Error(`Expected data UID be ${sdkUID} - got ${uid}`);
+  }
+});
+
 test("should error when the version parameter is missing", () => {
   const sdkUrl =
     "https://www.paypal.com/web-sdk/v6/bridge?origin=https%3A%2F%2Fwww.example.com%3A8000&payment-flow=payment-handler";


### PR DESCRIPTION
This PR updates the web-sdk query param validation logic so that `payment-flow` is considered an optional parameter.