### PR TITLE
fix: pin to version of flow-remove-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "esdoc-flow-type-plugin": "1.1.0",
     "esdoc-standard-plugin": "1.0.0",
     "flow-bin": "0.155.0",
+    "flow-remove-types": "2.232.0",
     "flow-typed": "^3.8.0",
     "husky": "^8.0.1",
     "jsdom": "^20.0.3",


### PR DESCRIPTION
[flow-remove-types](https://www.npmjs.com/package/flow-remove-types?activeTab=readme) was recently updated which seems to have broken our `npm run release` task (ex: https://github.com/paypal/paypal-sdk-client/actions/runs/11463927109/job/31898934970). This PR should fix the following flow error:

```
Error -------------------------------------------- node_modules/hermes-parser/dist/traverse/getVisitorKeys.js.flow:18:50

Unexpected identifier, expected the token `{`

   18| export function isNode(thing: mixed) /*: implies thing is {+[string]: mixed} */ {
```