### PR TITLE
feat: support new method to validate url

### DIFF
--- a/src/domains.js
+++ b/src/domains.js
@@ -80,3 +80,17 @@ export function isPayPalTrustedDomain(): boolean {
     Boolean(getDomain().match(getVenmoDomainRegex()))
   );
 }
+
+export function isPayPalTrustedUrl(href: string): boolean {
+  try {
+    // eslint-disable-next-line compat/compat
+    const url = new URL(href);
+    const domain = url.origin;
+    return (
+      Boolean(domain.match(getPayPalDomainRegex())) ||
+      Boolean(domain.match(getVenmoDomainRegex()))
+    );
+  } catch (err) {
+    return false;
+  }
+}


### PR DESCRIPTION
- Support a new method `isPayPalTrustedUrl()` which validates if the provided URL is PayPal or Venmo URL. 
- Using the standard URL object instead of `getActualDomain` for future compatibility https://github.com/krakenjs/cross-domain-utils/blob/8f7bb2d9e07c465a5c625724b980f1f551dd28fa/src/utils.js#L91 