### PR TITLE
Adding globalSession to maintain the global_paypal storage

### DIFF
--- a/src/globalSession.js
+++ b/src/globalSession.js
@@ -2,12 +2,19 @@
 
 import { getStorage, type Storage } from "@krakenjs/belter/src";
 import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
+
 import { getVersion } from "./global";
+import { getLogger } from "./logger";
 
 const GLOBAL_SESSION_ID_KEY = "globalSessionID";
 
 export function getGlobalSessionName(): string {
-  const sdkVersion = String(getVersion()).replace(/[\W]+/g, "_");
+  let version = getVersion();
+  if (!version) {
+    getLogger().warn("global_session_no_sdk_version");
+    version = "unknown";
+  }
+  const sdkVersion = String(version).replace(/[\W]+/g, "_");
   return `paypal_global_${sdkVersion}`;
 }
 
@@ -19,15 +26,27 @@ function getGlobalStorageState<T>(handler: (storage: Object) => T): T {
   return getGlobalSessionStorage().getState(handler);
 }
 
-export function getGlobalSessionID(): string | undefined {
-  const globalSessionID = getGlobalStorageState((state) =>
-    ZalgoPromise.resolve(state[GLOBAL_SESSION_ID_KEY])
-  );
-  return globalSessionID.value;
+export function getGlobalSessionID(): string | void {
+  const globalSessionID = getGlobalStorageState((state) => {
+    if (
+      !state ||
+      typeof state !== "object" ||
+      !state.hasOwnProperty(GLOBAL_SESSION_ID_KEY)
+    ) {
+      getLogger().warn("global_session_not_found");
+      return undefined;
+    }
+    return ZalgoPromise.resolve(state[GLOBAL_SESSION_ID_KEY]);
+  });
+  return globalSessionID?.value;
 }
 
 export function setGlobalSessionID(sessionID: string): void {
   getGlobalSessionStorage().getState((state) => {
+    if (!state || typeof state !== "object") {
+      getLogger().warn("global_session_no_storage_state_found");
+      state = {};
+    }
     state[GLOBAL_SESSION_ID_KEY] = sessionID;
     return ZalgoPromise.resolve();
   });

--- a/src/globalSession.js
+++ b/src/globalSession.js
@@ -1,0 +1,34 @@
+/* @flow */
+
+import { getStorage, type Storage } from "@krakenjs/belter/src";
+import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
+import { getVersion } from "./global";
+
+const GLOBAL_SESSION_ID_KEY = "globalSessionID";
+
+export function getGlobalSessionName(): string {
+  const sdkVersion = String(getVersion()).replace(/[\W]+/g, "_");
+  return `paypal_global_${sdkVersion}`;
+}
+
+function getGlobalSessionStorage(): Storage {
+  return getStorage({ name: getGlobalSessionName() });
+}
+
+function getGlobalStorageState<T>(handler: (storage: Object) => T): T {
+  return getGlobalSessionStorage().getState(handler);
+}
+
+export function getGlobalSessionID(): string | undefined {
+  const globalSessionID = getGlobalStorageState((state) =>
+    ZalgoPromise.resolve(state[GLOBAL_SESSION_ID_KEY])
+  );
+  return globalSessionID.value;
+}
+
+export function setGlobalSessionID(sessionID: string): void {
+  getGlobalSessionStorage().getState((state) => {
+    state[GLOBAL_SESSION_ID_KEY] = sessionID;
+    return ZalgoPromise.resolve();
+  });
+}

--- a/src/globalSession.test.js
+++ b/src/globalSession.test.js
@@ -1,0 +1,74 @@
+import { describe, it, afterEach, expect, vi } from "vitest";
+import {
+  getGlobalSessionName,
+  getGlobalSessionID,
+  setGlobalSessionID,
+} from "./globalSession";
+import { getVersion } from "./global";
+
+vi.mock("@krakenjs/belter/src", async () => {
+  const actual = await vi.importActual("@krakenjs/belter/src");
+  let storageState = {};
+  return {
+    ...actual,
+    getStorage: vi.fn(() => ({
+      getState: (handler) => handler(storageState),
+      setState: (newState) => {
+        storageState = { ...storageState, ...newState };
+      },
+    })),
+  };
+});
+
+vi.mock("./global", () => ({
+  getVersion: vi.fn(() => "5.0.500"),
+}));
+
+describe("globalSession", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should generate the correct global session storage name", () => {
+    const expectedName = "paypal_global_5_0_500";
+
+    const name = getGlobalSessionName();
+
+    expect(name).toBe(expectedName);
+  });
+
+  it("should return undefined if globalSessionID is not set", () => {
+    const sessionID = getGlobalSessionID();
+
+    expect(sessionID).toBeUndefined();
+  });
+
+  it("should set and get the globalSessionID", () => {
+    const testID = "uid_123456";
+    setGlobalSessionID(testID);
+
+    const sessionID = getGlobalSessionID();
+
+    expect(sessionID).toBe(testID);
+  });
+
+  it("should overwrite the globalSessionID if set multiple times", () => {
+    const firstID = "uid_first";
+    const secondID = "uid_second";
+
+    setGlobalSessionID(firstID);
+    setGlobalSessionID(secondID);
+    const sessionID = getGlobalSessionID();
+
+    expect(sessionID).toBe(secondID);
+  });
+
+  it("should handle setting globalSessionID to an empty string", () => {
+    const emptyID = "";
+
+    setGlobalSessionID(emptyID);
+    const sessionID = getGlobalSessionID();
+
+    expect(sessionID).toBe(emptyID);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -17,4 +17,5 @@ export * from "./graphql";
 export * from "./domains";
 export * from "./tracking";
 export * from "./utils";
+export * from "./globalSession";
 export { buildDPoPHeaders } from "./dpop";


### PR DESCRIPTION
## What is the purpose of this PR?
Retrieve `globalSessionID` value from a new session created by Messaging components when more than a namespace are being used at the same time. Besides retrieving it, we should log the data on tracking button events on a prop named `global_session_id`

## Type of change <!-- Check all that best describe your change. -->

- [x] New feature (backward compatible change that adds new capability).
- [ ] UI change
- [ ] Bug fix.
- [ ] Breaking change (backward incompatible change). Provide references to customer impact and communication.
- [ ] Refactor (no functional change)

## Testing Plan

Here's the step by step to check if this change is working, but both changes on `paypal-sdk-client`, `smartcomponentnodeweb`, `paypal-sdk-constants` and `paypal-checkout-components` are needed

- Open your site, network tab and wait for logger requests
- Wait for any button event like `process_button_load`
- Check if `global_session_id` property exists. IT SHOULDN'T
- After it, go to console, copy and paste this:
```
window.localStorage.__paypal_global_5_0_500_storage__ = JSON.stringify({
   globalSessionID: "uid_testID",
})
```
- Reload the page and check the same logger, the `global_session_id` should be present and with uid_testID as its value
