### PR TITLE
fix: update npm access token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,5 +31,6 @@ jobs:
       - name: Publish to npm
         run: npm run release
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # actions/setup-node uses this NODE_AUTH_TOKEN environment variable for npm publishing
+          # https://docs.github.com/en/actions/tutorials/publish-packages/publish-nodejs-packages
+          NODE_AUTH_TOKEN: ${{ secrets.PAYPAL_SDK_NPM_AUTH_TOKEN }}


### PR DESCRIPTION
This PR updates the token used for publishing to npm